### PR TITLE
feat(api): add bucket query to hero ban stats endpoint

### DIFF
--- a/api/src/routes/v1/analytics/hero_ban_stats.rs
+++ b/api/src/routes/v1/analytics/hero_ban_stats.rs
@@ -6,6 +6,7 @@ use cached::TimedCache;
 use cached::proc_macro::cached;
 use clickhouse::Row;
 use serde::{Deserialize, Serialize};
+use strum::Display;
 use tracing::debug;
 use utoipa::{IntoParams, ToSchema};
 
@@ -14,8 +15,57 @@ use crate::context::AppState;
 use crate::error::APIResult;
 use crate::utils::parse::{MIN_DEMO_PLAYER_TIMESTAMP, default_last_month_timestamp};
 
+#[derive(Debug, Clone, Copy, Deserialize, ToSchema, Default, Display, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum BucketQuery {
+    /// No Bucketing
+    #[default]
+    NoBucket,
+    /// Bucket Hero Ban Stats By Max Average Badge Level (tier = first digits, subtier = last digit) of both teams involved. See more: <https://assets.deadlock-api.com/v2/ranks>
+    AvgBadge,
+    /// Bucket Hero Ban Stats By Start Time (Hour)
+    StartTimeHour,
+    /// Bucket Hero Ban Stats By Start Time (Day)
+    StartTimeDay,
+    /// Bucket Hero Ban Stats By Start Time (Week)
+    StartTimeWeek,
+    /// Bucket Hero Ban Stats By Start Time (Month)
+    StartTimeMonth,
+}
+
+impl BucketQuery {
+    fn get_select_clause(self) -> &'static str {
+        match self {
+            Self::NoBucket => "toUInt32(0)",
+            Self::AvgBadge => "toUInt32(max_avg_badge)",
+            Self::StartTimeHour => "toStartOfHour(start_time)",
+            Self::StartTimeDay => "toStartOfDay(start_time)",
+            Self::StartTimeWeek => "toDateTime(toStartOfWeek(start_time))",
+            Self::StartTimeMonth => "toDateTime(toStartOfMonth(start_time))",
+        }
+    }
+
+    fn get_info_select_clause(self) -> &'static str {
+        match self {
+            Self::StartTimeHour
+            | Self::StartTimeDay
+            | Self::StartTimeWeek
+            | Self::StartTimeMonth => ", start_time",
+            Self::AvgBadge => {
+                ", assumeNotNull(coalesce(greatest(average_badge_team0, average_badge_team1), 0)) as max_avg_badge"
+            }
+            Self::NoBucket => "",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, IntoParams, Eq, PartialEq, Hash, Default)]
 pub(super) struct HeroBanStatsQuery {
+    /// Bucket allows you to group the stats by a specific field.
+    #[serde(default)]
+    #[param(inline)]
+    bucket: BucketQuery,
     /// Filter matches based on their start time (Unix timestamp). **Default:** 30 days ago. **Minimum:** March 1, 2026.
     #[serde(default = "default_last_month_timestamp")]
     #[param(default = default_last_month_timestamp)]
@@ -44,6 +94,8 @@ pub(super) struct HeroBanStatsQuery {
 pub struct HeroBanStats {
     /// The ID of the banned hero. See more: <https://assets.deadlock-api.com/v2/heroes>
     pub hero_id: u32,
+    /// The bucket value (depends on the bucket query parameter).
+    pub bucket: u32,
     /// The number of matches in which this hero was banned.
     pub bans: u64,
 }
@@ -60,10 +112,12 @@ fn build_query(query: &HeroBanStatsQuery) -> String {
         max_duration_s: query.max_duration_s,
     }
     .build();
+    let bucket = query.bucket.get_select_clause();
+    let match_info_select = query.bucket.get_info_select_clause();
     format!(
         "
     WITH t_matches AS (
-        SELECT match_id
+        SELECT match_id {match_info_select}
         FROM match_info
         WHERE match_mode IN ('Ranked', 'Unranked') AND game_mode = 1 {info_filters}
     ),
@@ -73,11 +127,17 @@ fn build_query(query: &HeroBanStatsQuery) -> String {
         WHERE dp.match_id IN (SELECT match_id FROM t_matches) AND notEmpty(dp.banned_hero_ids)
         GROUP BY dp.match_id
     )
-    SELECT arrayJoin(banned_hero_ids) AS hero_id, uniq(match_id) AS bans
+    SELECT arrayJoin(banned_hero_ids) AS hero_id, {bucket} AS bucket, uniq(t_bans.match_id) AS bans
     FROM t_bans
-    GROUP BY hero_id
-    ORDER BY bans DESC
-    "
+    {join}
+    GROUP BY hero_id, bucket
+    ORDER BY hero_id, bucket
+    ",
+        join = if query.bucket == BucketQuery::NoBucket {
+            ""
+        } else {
+            "INNER JOIN t_matches USING (match_id)"
+        },
     )
 }
 


### PR DESCRIPTION
Allow grouping hero ban statistics by badge level or time intervals,
matching the bucketing capability already available in the hero stats endpoint.

https://claude.ai/code/session_01JwcY5GNkuEWMhMBp6xV8We