### PR TITLE
fix: correct year in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 202 Deadlock API
+Copyright (c) 2026 Deadlock API
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Nothing fancy, just fixing what I presume is a typo in the LICENSE file.
