### PR TITLE
fix(website): measure ElectricBorder with offsetWidth to ignore route transform

### DIFF
--- a/website/app/components/ElectricBorder.tsx
+++ b/website/app/components/ElectricBorder.tsx
@@ -169,9 +169,10 @@ export function ElectricBorder({
     const borderOffset = 60;
 
     const updateSize = () => {
-      const rect = container.getBoundingClientRect();
-      const width = rect.width + borderOffset * 2;
-      const height = rect.height + borderOffset * 2;
+      // offsetWidth/Height ignore ancestor CSS transforms (AnimatedOutlet's scale anim),
+      // unlike getBoundingClientRect which would size the canvas to the scaled box.
+      const width = container.offsetWidth + borderOffset * 2;
+      const height = container.offsetHeight + borderOffset * 2;
 
       const dpr = Math.min(window.devicePixelRatio || 1, 2);
       canvas.width = width * dpr;


### PR DESCRIPTION
getBoundingClientRect returns the rendered size including ancestor CSS
transforms, so the canvas was sized to the scaled-down box during
AnimatedOutlet's scale(0.98 → 1) transition. Once the animation settled
the electric border sat inside the box edges, most visibly at 2k+.