### PR TITLE
feat(website): add hero and item flashcards game

### DIFF
--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -24,6 +24,16 @@ app
 │   ├── streamkit_.widgets.$region.$accountId.$widgetType.tsx  # OBS embed: 3x zoom, transparent bg, auto-reload on version bump
 │   ├── data-privacy.tsx        # GDPR: data deletion & tracking re-enable via Steam OpenID auth
 │   ├── ingest-cache.tsx        # Community data tool: scans Steam httpcache binaries for replay URLs, uploads match salts
+│   ├── deadlockdle._index.tsx       # Deadlockdle landing: daily minigames hub, per-game status + share
+│   ├── deadlockdle.guess-hero.tsx   # Daily: identify hero from silhouette; clues revealed each guess
+│   ├── deadlockdle.guess-item.tsx   # Daily: name item from blurred shop image; clearer each attempt
+│   ├── deadlockdle.guess-sound.tsx  # Daily: listen to ability sound, name the ability
+│   ├── deadlockdle.guess-ability.tsx # Daily: name the ability from its icon
+│   ├── deadlockdle.item-stats.tsx   # Daily: fill in missing stats for items
+│   ├── deadlockdle.trivia.tsx       # Daily: 10 trivia questions (heroes, items, NPCs, mechanics)
+│   ├── flashcards._index.tsx   # Flashcards landing: links to hero and item games
+│   ├── flashcards.heroes.tsx   # Hero flashcards: identify hero by icon (4 choices)
+│   ├── flashcards.items.tsx    # Item flashcards: identify item by shop image (4 choices)
 │   ├── auth.patreon.callback.tsx  # OAuth callback: sets session cookie, redirects to /patron
 │   └── deadlockstats-privacy.tsx  # Mobile app privacy policy (static page)
 │

--- a/website/app/components/AppSidebar.tsx
+++ b/website/app/components/AppSidebar.tsx
@@ -5,6 +5,7 @@ import {
   BookOpen,
   Database,
   Gamepad2,
+  GraduationCap,
   HardDrive,
   Home,
   ImageIcon,
@@ -79,7 +80,10 @@ const navGroups: NavGroup[] = [
   },
   {
     label: "Games",
-    links: [{ to: "/deadlockdle", label: "Deadlockdle", icon: Gamepad2 }],
+    links: [
+      { to: "/deadlockdle", label: "Deadlockdle", icon: Gamepad2 },
+      { to: "/flashcards", label: "Flashcards", icon: GraduationCap },
+    ],
   },
 ];
 

--- a/website/app/queries/asset-queries.ts
+++ b/website/app/queries/asset-queries.ts
@@ -1,5 +1,5 @@
 import { queryOptions } from "@tanstack/react-query";
-import type { AbilityV2, UpgradeV2 } from "assets_deadlock_api_client/api";
+import type { AbilityV2, HeroV2, UpgradeV2 } from "assets_deadlock_api_client/api";
 
 import { CACHE_DURATIONS } from "~/constants/cache";
 import { assetsApi } from "~/lib/assets-api";
@@ -36,3 +36,11 @@ export const abilitiesQueryOptions = queryOptions({
   },
   staleTime: CACHE_DURATIONS.FOREVER,
 });
+
+export function filterPlayableHeroes(heroes: HeroV2[]): HeroV2[] {
+  return heroes.filter((h) => h.player_selectable && !h.disabled && !h.in_development);
+}
+
+export function filterShopableItems(items: UpgradeV2[]): UpgradeV2[] {
+  return items.filter((item) => item.shopable && !item.disabled && item.shop_image_webp);
+}

--- a/website/app/routes/deadlockdle.guess-ability.tsx
+++ b/website/app/routes/deadlockdle.guess-ability.tsx
@@ -6,13 +6,14 @@ import type { MetaFunction } from "react-router";
 import { LoadingLogo } from "~/components/LoadingLogo";
 import { createPageMeta } from "~/lib/meta";
 import { cn } from "~/lib/utils";
+import { filterPlayableHeroes } from "~/queries/asset-queries";
 
 import { GameShell } from "./deadlockdle/components/GameShell";
 import { GuessFeedback } from "./deadlockdle/components/GuessFeedback";
 import { GuessInput } from "./deadlockdle/components/GuessInput";
 import { HintReveal } from "./deadlockdle/components/HintReveal";
 import { ResultModal } from "./deadlockdle/components/ResultModal";
-import { filterPlayableHeroes, useAbilities, useHeroes } from "./deadlockdle/lib/queries";
+import { useAbilities, useHeroes } from "./deadlockdle/lib/queries";
 import { getModeSeed, seededPick, seededRandom } from "./deadlockdle/lib/seed";
 import { useDailyGame } from "./deadlockdle/lib/use-daily-game";
 

--- a/website/app/routes/deadlockdle.guess-hero.tsx
+++ b/website/app/routes/deadlockdle.guess-hero.tsx
@@ -5,13 +5,14 @@ import type { MetaFunction } from "react-router";
 import { LoadingLogo } from "~/components/LoadingLogo";
 import { createPageMeta } from "~/lib/meta";
 import { cn, snakeToPretty } from "~/lib/utils";
+import { filterPlayableHeroes } from "~/queries/asset-queries";
 
 import { GameShell } from "./deadlockdle/components/GameShell";
 import { GuessFeedback } from "./deadlockdle/components/GuessFeedback";
 import { GuessInput } from "./deadlockdle/components/GuessInput";
 import { HintReveal } from "./deadlockdle/components/HintReveal";
 import { ResultModal } from "./deadlockdle/components/ResultModal";
-import { filterPlayableHeroes, useHeroes } from "./deadlockdle/lib/queries";
+import { useHeroes } from "./deadlockdle/lib/queries";
 import { getModeSeed, seededPick, seededRandom } from "./deadlockdle/lib/seed";
 import { useDailyGame } from "./deadlockdle/lib/use-daily-game";
 

--- a/website/app/routes/deadlockdle.guess-item.tsx
+++ b/website/app/routes/deadlockdle.guess-item.tsx
@@ -5,13 +5,14 @@ import type { MetaFunction } from "react-router";
 import { LoadingLogo } from "~/components/LoadingLogo";
 import { createPageMeta } from "~/lib/meta";
 import { cn } from "~/lib/utils";
+import { filterShopableItems } from "~/queries/asset-queries";
 
 import { GameShell } from "./deadlockdle/components/GameShell";
 import { GuessFeedback } from "./deadlockdle/components/GuessFeedback";
 import { GuessInput } from "./deadlockdle/components/GuessInput";
 import { HintReveal } from "./deadlockdle/components/HintReveal";
 import { ResultModal } from "./deadlockdle/components/ResultModal";
-import { filterShopableItems, useItems } from "./deadlockdle/lib/queries";
+import { useItems } from "./deadlockdle/lib/queries";
 import { getModeSeed, seededPick, seededRandom } from "./deadlockdle/lib/seed";
 import { useDailyGame } from "./deadlockdle/lib/use-daily-game";
 

--- a/website/app/routes/deadlockdle.guess-sound.tsx
+++ b/website/app/routes/deadlockdle.guess-sound.tsx
@@ -7,13 +7,14 @@ import type { MetaFunction } from "react-router";
 import { LoadingLogo } from "~/components/LoadingLogo";
 import { createPageMeta } from "~/lib/meta";
 import { cn } from "~/lib/utils";
+import { filterPlayableHeroes } from "~/queries/asset-queries";
 
 import { GameShell } from "./deadlockdle/components/GameShell";
 import { GuessFeedback } from "./deadlockdle/components/GuessFeedback";
 import { GuessInput } from "./deadlockdle/components/GuessInput";
 import { HintReveal } from "./deadlockdle/components/HintReveal";
 import { ResultModal } from "./deadlockdle/components/ResultModal";
-import { filterPlayableHeroes, useAbilities, useHeroes, useSounds } from "./deadlockdle/lib/queries";
+import { useAbilities, useHeroes, useSounds } from "./deadlockdle/lib/queries";
 import { getModeSeed, seededPick, seededRandom } from "./deadlockdle/lib/seed";
 import { useDailyGame } from "./deadlockdle/lib/use-daily-game";
 

--- a/website/app/routes/deadlockdle.item-stats.tsx
+++ b/website/app/routes/deadlockdle.item-stats.tsx
@@ -8,10 +8,11 @@ import { LoadingLogo } from "~/components/LoadingLogo";
 import { Button } from "~/components/ui/button";
 import { createPageMeta } from "~/lib/meta";
 import { cn } from "~/lib/utils";
+import { filterShopableItems } from "~/queries/asset-queries";
 
 import { GameShell } from "./deadlockdle/components/GameShell";
 import { NextGameButton } from "./deadlockdle/components/NextGameButton";
-import { filterShopableItems, useItems } from "./deadlockdle/lib/queries";
+import { useItems } from "./deadlockdle/lib/queries";
 import { getDayNumber, getModeSeed, getTodayDate, seededRandom, seededShuffle } from "./deadlockdle/lib/seed";
 import { useCountdown } from "./deadlockdle/lib/use-countdown";
 

--- a/website/app/routes/deadlockdle.trivia.tsx
+++ b/website/app/routes/deadlockdle.trivia.tsx
@@ -9,11 +9,12 @@ import { LoadingLogo } from "~/components/LoadingLogo";
 import { Button } from "~/components/ui/button";
 import { createPageMeta } from "~/lib/meta";
 import { cn } from "~/lib/utils";
+import { filterPlayableHeroes } from "~/queries/asset-queries";
 
 import { GameShell } from "./deadlockdle/components/GameShell";
 import { GuessFeedback } from "./deadlockdle/components/GuessFeedback";
 import { NextGameButton } from "./deadlockdle/components/NextGameButton";
-import { filterPlayableHeroes, useAbilities, useHeroes, useItems, useNpcUnits } from "./deadlockdle/lib/queries";
+import { useAbilities, useHeroes, useItems, useNpcUnits } from "./deadlockdle/lib/queries";
 import { getDayNumber, getModeSeed, getTodayDate, seededRandom } from "./deadlockdle/lib/seed";
 import {
   buildAbilitiesWithHeroes,

--- a/website/app/routes/deadlockdle/lib/queries.ts
+++ b/website/app/routes/deadlockdle/lib/queries.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import type { HeroV2, UpgradeV2 } from "assets_deadlock_api_client/api";
+import type { UpgradeV2 } from "assets_deadlock_api_client/api";
 import axios from "axios";
 
 import { assetsApi } from "~/lib/assets-api";
@@ -81,10 +81,3 @@ export function useGenericData() {
   });
 }
 
-export function filterPlayableHeroes(heroes: HeroV2[]): HeroV2[] {
-  return heroes.filter((h) => h.player_selectable && !h.disabled && !h.in_development);
-}
-
-export function filterShopableItems(items: UpgradeV2[]): UpgradeV2[] {
-  return items.filter((item) => item.shopable && !item.disabled && item.shop_image_webp);
-}

--- a/website/app/routes/deadlockdle/lib/queries.ts
+++ b/website/app/routes/deadlockdle/lib/queries.ts
@@ -80,4 +80,3 @@ export function useGenericData() {
     staleTime: Number.POSITIVE_INFINITY,
   });
 }
-

--- a/website/app/routes/deadlockdle/lib/trivia-questions.ts
+++ b/website/app/routes/deadlockdle/lib/trivia-questions.ts
@@ -1,6 +1,7 @@
 import type { AbilityV2, HeroV2, UpgradeV2 } from "assets_deadlock_api_client/api";
 
-import { filterPlayableHeroes, filterShopableItems } from "./queries";
+import { filterPlayableHeroes, filterShopableItems } from "~/queries/asset-queries";
+
 import { seededPick, seededShuffle } from "./seed";
 
 export interface TriviaQuestion {

--- a/website/app/routes/flashcards._index.tsx
+++ b/website/app/routes/flashcards._index.tsx
@@ -1,0 +1,112 @@
+import { motion } from "framer-motion";
+import { ArrowRight, ShoppingBag, Swords } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { MetaFunction } from "react-router";
+import { Link } from "react-router";
+
+import { createPageMeta } from "~/lib/meta";
+
+export const meta: MetaFunction = () => {
+  return createPageMeta({
+    title: "Flashcards - Learn Deadlock Heroes and Items | Deadlock API",
+    description: "Practice identifying Deadlock heroes and items by icon with multiple-choice flashcards.",
+    path: "/flashcards",
+  });
+};
+
+const GAMES: {
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  path: string;
+}[] = [
+  {
+    title: "Hero Flashcards",
+    description: "Identify heroes by their icon. Pick the correct name from four choices.",
+    icon: Swords,
+    path: "/flashcards/heroes",
+  },
+  {
+    title: "Item Flashcards",
+    description: "Identify shop items by their icon. Pick the correct name from four choices.",
+    icon: ShoppingBag,
+    path: "/flashcards/items",
+  },
+];
+
+const stagger = {
+  hidden: {},
+  show: { transition: { staggerChildren: 0.07 } },
+};
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 16 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.4, ease: "easeOut" as const },
+  },
+};
+
+export default function FlashcardsHub() {
+  return (
+    <div className="space-y-10">
+      <section className="relative pt-4 pb-2 text-center">
+        <div className="pointer-events-none absolute top-0 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-primary/8 blur-[100px]" />
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.5, ease: "easeOut" }}
+          className="relative"
+        >
+          <h1 className="bg-linear-to-b from-foreground to-foreground/60 bg-clip-text font-game text-5xl font-normal tracking-tight text-transparent lg:text-6xl">
+            Flashcards
+          </h1>
+        </motion.div>
+
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.15, duration: 0.4 }}
+          className="mx-auto mt-3 max-w-lg text-sm text-muted-foreground"
+        >
+          Drill Deadlock heroes and items until you know every icon by heart.
+        </motion.p>
+      </section>
+
+      <section className="mx-auto max-w-3xl">
+        <motion.div
+          variants={stagger}
+          initial="hidden"
+          animate="show"
+          className="grid grid-cols-1 gap-3 sm:grid-cols-2"
+        >
+          {GAMES.map((game) => {
+            const Icon = game.icon;
+            return (
+              <motion.div key={game.path} variants={fadeUp}>
+                <Link to={game.path} prefetch="intent" className="group block h-full">
+                  <div className="flex h-full flex-col border border-border bg-card p-4 transition-colors hover:border-primary/30 hover:bg-muted/30">
+                    <div className="mb-2 flex items-center gap-3">
+                      <div className="flex size-8 shrink-0 items-center justify-center border border-border bg-muted transition-colors group-hover:border-primary/20 group-hover:bg-primary/5">
+                        <Icon className="size-4 text-muted-foreground transition-colors group-hover:text-primary" />
+                      </div>
+                      <h3 className="text-sm font-semibold text-foreground">{game.title}</h3>
+                    </div>
+                    <p className="text-xs leading-relaxed text-muted-foreground">{game.description}</p>
+                    <div className="mt-auto flex items-center justify-between pt-2">
+                      <span className="flex items-center gap-1 text-xs font-medium text-primary/80 transition-colors group-hover:text-primary">
+                        Play
+                        <ArrowRight className="size-3 transition-transform group-hover:translate-x-0.5" />
+                      </span>
+                    </div>
+                  </div>
+                </Link>
+              </motion.div>
+            );
+          })}
+        </motion.div>
+      </section>
+    </div>
+  );
+}

--- a/website/app/routes/flashcards.heroes.tsx
+++ b/website/app/routes/flashcards.heroes.tsx
@@ -37,7 +37,7 @@ export default function HeroFlashcards() {
       isLoading={isLoading}
       storageKey="flashcards:heroes:no-repeats"
       altLabel="Mystery hero"
-      completionLabel="All heroes seen"
+      masteredLabel="All heroes mastered"
     />
   );
 }

--- a/website/app/routes/flashcards.heroes.tsx
+++ b/website/app/routes/flashcards.heroes.tsx
@@ -1,0 +1,44 @@
+import { useQuery } from "@tanstack/react-query";
+import type { HeroV2 } from "assets_deadlock_api_client/api";
+import { useMemo } from "react";
+import type { MetaFunction } from "react-router";
+
+import { createPageMeta } from "~/lib/meta";
+import { heroesQueryOptions } from "~/queries/asset-queries";
+
+import { filterPlayableHeroes } from "./deadlockdle/lib/queries";
+import { FlashcardGame } from "./flashcards/components/FlashcardGame";
+
+export const meta: MetaFunction = () => {
+  return createPageMeta({
+    title: "Hero Flashcards - Learn Heroes by Icon | Deadlock API",
+    description: "Memorize Deadlock heroes by their icon. Multiple-choice flashcard drill with instant feedback.",
+    path: "/flashcards/heroes",
+  });
+};
+
+function heroIconSrc(hero: HeroV2): string {
+  return hero.images?.icon_image_small_webp ?? hero.images?.icon_image_small ?? "";
+}
+
+export default function HeroFlashcards() {
+  const { data: heroes, isLoading } = useQuery(heroesQueryOptions);
+
+  const pool = useMemo(() => {
+    if (!heroes) return [];
+    return filterPlayableHeroes(heroes);
+  }, [heroes]);
+
+  return (
+    <FlashcardGame
+      title="Hero Flashcards"
+      subtitle="Identify the hero from their icon. Pick the correct name."
+      pool={pool}
+      getIcon={heroIconSrc}
+      isLoading={isLoading}
+      storageKey="flashcards:heroes:no-repeats"
+      altLabel="Mystery hero"
+      completionLabel="All heroes seen"
+    />
+  );
+}

--- a/website/app/routes/flashcards.heroes.tsx
+++ b/website/app/routes/flashcards.heroes.tsx
@@ -4,9 +4,8 @@ import { useMemo } from "react";
 import type { MetaFunction } from "react-router";
 
 import { createPageMeta } from "~/lib/meta";
-import { heroesQueryOptions } from "~/queries/asset-queries";
+import { filterPlayableHeroes, heroesQueryOptions } from "~/queries/asset-queries";
 
-import { filterPlayableHeroes } from "./deadlockdle/lib/queries";
 import { FlashcardGame } from "./flashcards/components/FlashcardGame";
 
 export const meta: MetaFunction = () => {

--- a/website/app/routes/flashcards.items.tsx
+++ b/website/app/routes/flashcards.items.tsx
@@ -4,9 +4,8 @@ import { useMemo } from "react";
 import type { MetaFunction } from "react-router";
 
 import { createPageMeta } from "~/lib/meta";
-import { itemUpgradesQueryOptions } from "~/queries/asset-queries";
+import { filterShopableItems, itemUpgradesQueryOptions } from "~/queries/asset-queries";
 
-import { filterShopableItems } from "./deadlockdle/lib/queries";
 import { FlashcardGame } from "./flashcards/components/FlashcardGame";
 
 export const meta: MetaFunction = () => {

--- a/website/app/routes/flashcards.items.tsx
+++ b/website/app/routes/flashcards.items.tsx
@@ -1,0 +1,52 @@
+import { useQuery } from "@tanstack/react-query";
+import type { UpgradeV2 } from "assets_deadlock_api_client/api";
+import { useMemo } from "react";
+import type { MetaFunction } from "react-router";
+
+import { createPageMeta } from "~/lib/meta";
+import { itemUpgradesQueryOptions } from "~/queries/asset-queries";
+
+import { filterShopableItems } from "./deadlockdle/lib/queries";
+import { FlashcardGame } from "./flashcards/components/FlashcardGame";
+
+export const meta: MetaFunction = () => {
+  return createPageMeta({
+    title: "Item Flashcards - Learn Items by Icon | Deadlock API",
+    description: "Memorize Deadlock shop items by their icon. Multiple-choice flashcard drill with instant feedback.",
+    path: "/flashcards/items",
+  });
+};
+
+function itemIconSrc(item: UpgradeV2): string {
+  return (
+    item.shop_image_webp ??
+    item.shop_image ??
+    item.shop_image_small_webp ??
+    item.shop_image_small ??
+    item.image_webp ??
+    item.image ??
+    ""
+  );
+}
+
+export default function ItemFlashcards() {
+  const { data: items, isLoading } = useQuery(itemUpgradesQueryOptions);
+
+  const pool = useMemo(() => {
+    if (!items) return [];
+    return filterShopableItems(items);
+  }, [items]);
+
+  return (
+    <FlashcardGame
+      title="Item Flashcards"
+      subtitle="Identify the shop item from its icon. Pick the correct name."
+      pool={pool}
+      getIcon={itemIconSrc}
+      isLoading={isLoading}
+      storageKey="flashcards:items:no-repeats"
+      altLabel="Mystery item"
+      completionLabel="All items seen"
+    />
+  );
+}

--- a/website/app/routes/flashcards.items.tsx
+++ b/website/app/routes/flashcards.items.tsx
@@ -37,7 +37,7 @@ export default function ItemFlashcards() {
       isLoading={isLoading}
       storageKey="flashcards:items:no-repeats"
       altLabel="Mystery item"
-      completionLabel="All items seen"
+      masteredLabel="All items mastered"
     />
   );
 }

--- a/website/app/routes/flashcards.items.tsx
+++ b/website/app/routes/flashcards.items.tsx
@@ -17,15 +17,7 @@ export const meta: MetaFunction = () => {
 };
 
 function itemIconSrc(item: UpgradeV2): string {
-  return (
-    item.shop_image_webp ??
-    item.shop_image ??
-    item.shop_image_small_webp ??
-    item.shop_image_small ??
-    item.image_webp ??
-    item.image ??
-    ""
-  );
+  return item.shop_image_webp ?? "";
 }
 
 export default function ItemFlashcards() {

--- a/website/app/routes/flashcards/components/FlashcardGame.tsx
+++ b/website/app/routes/flashcards/components/FlashcardGame.tsx
@@ -88,10 +88,10 @@ function FlashcardGameReady<T extends FlashcardEntry>({
   });
   const advanceTimer = useRef<number | null>(null);
   const noRepeatsRef = useRef(noRepeats);
-  noRepeatsRef.current = noRepeats;
 
   const updateNoRepeats = useCallback(
     (value: boolean) => {
+      noRepeatsRef.current = value;
       setNoRepeats(value);
       localStorage.setItem(storageKey, String(value));
     },

--- a/website/app/routes/flashcards/components/FlashcardGame.tsx
+++ b/website/app/routes/flashcards/components/FlashcardGame.tsx
@@ -87,6 +87,8 @@ function FlashcardGameReady<T extends FlashcardEntry>({
     return localStorage.getItem(storageKey) === "true";
   });
   const advanceTimer = useRef<number | null>(null);
+  const noRepeatsRef = useRef(noRepeats);
+  noRepeatsRef.current = noRepeats;
 
   const updateNoRepeats = useCallback(
     (value: boolean) => {
@@ -122,13 +124,13 @@ function FlashcardGameReady<T extends FlashcardEntry>({
         () => {
           setSelected(null);
           setSeenIds(nextSeen);
-          const exclude = noRepeats ? nextSeen : new Set<number>([card.answer.id]);
+          const exclude = noRepeatsRef.current ? nextSeen : new Set<number>([card.answer.id]);
           setCard(pickCard(pool, exclude));
         },
         correct ? CORRECT_FEEDBACK_MS : WRONG_FEEDBACK_MS,
       );
     },
-    [card, selected, pool, seenIds, noRepeats],
+    [card, selected, pool, seenIds],
   );
 
   const resetStats = useCallback(() => {

--- a/website/app/routes/flashcards/components/FlashcardGame.tsx
+++ b/website/app/routes/flashcards/components/FlashcardGame.tsx
@@ -1,0 +1,306 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { ArrowLeft, Check, RotateCcw, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link } from "react-router";
+
+import { LoadingLogo } from "~/components/LoadingLogo";
+import { Button } from "~/components/ui/button";
+import { Checkbox } from "~/components/ui/checkbox";
+import { cn } from "~/lib/utils";
+
+const OPTION_COUNT = 4;
+const CORRECT_FEEDBACK_MS = 450;
+const WRONG_FEEDBACK_MS = 1800;
+
+export interface FlashcardEntry {
+  id: number;
+  name: string;
+}
+
+interface Card<T extends FlashcardEntry> {
+  answer: T;
+  options: T[];
+}
+
+function pickCard<T extends FlashcardEntry>(pool: T[], excludeIds: Set<number>): Card<T> | null {
+  const answerPool = pool.filter((h) => !excludeIds.has(h.id));
+  if (answerPool.length === 0) return null;
+  const answer = answerPool[Math.floor(Math.random() * answerPool.length)];
+
+  const distractors: T[] = [];
+  const used = new Set<number>([answer.id]);
+  const optionTarget = Math.min(OPTION_COUNT, pool.length);
+  while (distractors.length < optionTarget - 1) {
+    const candidate = pool[Math.floor(Math.random() * pool.length)];
+    if (used.has(candidate.id)) continue;
+    used.add(candidate.id);
+    distractors.push(candidate);
+  }
+
+  const options = [answer, ...distractors];
+  for (let i = options.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [options[i], options[j]] = [options[j], options[i]];
+  }
+
+  return { answer, options };
+}
+
+export interface FlashcardGameProps<T extends FlashcardEntry> {
+  title: string;
+  subtitle: string;
+  pool: T[];
+  getIcon: (entry: T) => string;
+  isLoading: boolean;
+  storageKey: string;
+  altLabel: string;
+  completionLabel: string;
+}
+
+export function FlashcardGame<T extends FlashcardEntry>(props: FlashcardGameProps<T>) {
+  if (props.isLoading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <LoadingLogo className="h-16 w-16 animate-pulse" />
+      </div>
+    );
+  }
+  return <FlashcardGameReady key={props.storageKey} {...props} />;
+}
+
+function FlashcardGameReady<T extends FlashcardEntry>({
+  title,
+  subtitle,
+  pool,
+  getIcon,
+  storageKey,
+  altLabel,
+  completionLabel,
+}: FlashcardGameProps<T>) {
+  const [card, setCard] = useState<Card<T> | null>(() => (pool.length > 0 ? pickCard(pool, new Set()) : null));
+  const [selected, setSelected] = useState<number | null>(null);
+  const [stats, setStats] = useState({ correct: 0, seen: 0, streak: 0, bestStreak: 0 });
+  const [seenIds, setSeenIds] = useState<Set<number>>(new Set());
+  const [noRepeats, setNoRepeats] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return localStorage.getItem(storageKey) === "true";
+  });
+  const advanceTimer = useRef<number | null>(null);
+
+  const updateNoRepeats = useCallback(
+    (value: boolean) => {
+      setNoRepeats(value);
+      localStorage.setItem(storageKey, String(value));
+    },
+    [storageKey],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (advanceTimer.current !== null) window.clearTimeout(advanceTimer.current);
+    };
+  }, []);
+
+  const handleChoice = useCallback(
+    (id: number) => {
+      if (!card || selected !== null) return;
+      setSelected(id);
+      const correct = id === card.answer.id;
+      setStats((prev) => {
+        const nextStreak = correct ? prev.streak + 1 : 0;
+        return {
+          correct: prev.correct + (correct ? 1 : 0),
+          seen: prev.seen + 1,
+          streak: nextStreak,
+          bestStreak: Math.max(prev.bestStreak, nextStreak),
+        };
+      });
+      const nextSeen = new Set(seenIds);
+      if (correct) nextSeen.add(card.answer.id);
+      advanceTimer.current = window.setTimeout(
+        () => {
+          setSelected(null);
+          setSeenIds(nextSeen);
+          const exclude = noRepeats ? nextSeen : new Set<number>([card.answer.id]);
+          setCard(pickCard(pool, exclude));
+        },
+        correct ? CORRECT_FEEDBACK_MS : WRONG_FEEDBACK_MS,
+      );
+    },
+    [card, selected, pool, seenIds, noRepeats],
+  );
+
+  const resetStats = useCallback(() => {
+    if (advanceTimer.current !== null) window.clearTimeout(advanceTimer.current);
+    setStats({ correct: 0, seen: 0, streak: 0, bestStreak: 0 });
+    setSelected(null);
+    setSeenIds(new Set());
+    setCard(pool.length > 0 ? pickCard(pool, new Set()) : null);
+  }, [pool]);
+
+  const accuracy = stats.seen > 0 ? Math.round((stats.correct / stats.seen) * 100) : 0;
+  const exhausted = noRepeats && pool.length > 0 && seenIds.size >= pool.length;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+      className="mx-auto max-w-3xl px-4 py-8"
+    >
+      <div className="mb-6">
+        <Link
+          to="/flashcards"
+          className="mb-4 inline-flex items-center gap-1.5 font-mono text-xs tracking-wider text-muted-foreground/50 uppercase transition-colors hover:text-primary"
+        >
+          <ArrowLeft className="h-3 w-3" />
+          Back to Hub
+        </Link>
+        <h1 className="bg-linear-to-b from-foreground to-foreground/50 bg-clip-text font-game text-2xl tracking-tight text-transparent uppercase">
+          {title}
+        </h1>
+        <p className="mt-1 font-mono text-sm text-muted-foreground/60">{subtitle}</p>
+      </div>
+
+      <div className="mb-3 flex flex-wrap items-center gap-3 border border-border bg-card/40 px-4 py-3 font-mono text-xs tracking-wider uppercase">
+        <Stat label="Correct" value={`${stats.correct}/${stats.seen}`} />
+        <Divider />
+        <Stat label="Accuracy" value={`${accuracy}%`} />
+        <Divider />
+        <Stat label="Streak" value={`${stats.streak}`} highlight={stats.streak >= 3} />
+        <Divider />
+        <Stat label="Best" value={`${stats.bestStreak}`} />
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={resetStats}
+          disabled={stats.seen === 0}
+          className="ml-auto h-7 gap-1.5 px-2 text-xs"
+        >
+          <RotateCcw className="size-3" />
+          Reset
+        </Button>
+      </div>
+
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3 px-1 font-mono text-xs tracking-wider uppercase">
+        <label className="flex cursor-pointer items-center gap-2 text-muted-foreground/70 hover:text-foreground">
+          <Checkbox checked={noRepeats} onCheckedChange={(v) => updateNoRepeats(v === true)} />
+          <span>No repeats</span>
+          {noRepeats && (
+            <span className="text-muted-foreground/40 normal-case">
+              ({seenIds.size}/{pool.length} seen)
+            </span>
+          )}
+        </label>
+      </div>
+
+      {exhausted || !card ? (
+        <motion.div
+          initial={{ opacity: 0, scale: 0.96 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.25, ease: "easeOut" }}
+          className="flex flex-col items-center gap-4 border border-green-500/30 bg-green-500/5 px-6 py-12 text-center"
+        >
+          <div className="flex size-12 items-center justify-center rounded-full bg-green-500/15 text-green-400">
+            <Check className="size-6" />
+          </div>
+          <div>
+            <p className="font-game text-xl tracking-tight text-foreground uppercase">{completionLabel}</p>
+            <p className="mt-1 font-mono text-xs tracking-wider text-muted-foreground/60 uppercase">
+              You got {stats.correct}/{stats.seen} correct ({accuracy}%)
+            </p>
+          </div>
+          <Button onClick={resetStats} variant="outline" className="gap-2">
+            <RotateCcw className="size-4" />
+            Play again
+          </Button>
+        </motion.div>
+      ) : (
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={card.answer.id}
+            initial={{ opacity: 0, scale: 0.96 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 1.02 }}
+            transition={{ duration: 0.18, ease: "easeOut" }}
+            className="flex flex-col items-center gap-6"
+          >
+            <div className="relative">
+              <div
+                className={cn(
+                  "flex size-40 items-center justify-center overflow-hidden rounded-2xl border bg-muted/30 ring-1 transition-colors duration-200 sm:size-52",
+                  selected === null
+                    ? "border-border/80 ring-border/30"
+                    : selected === card.answer.id
+                      ? "border-green-500/50 ring-green-500/30"
+                      : "border-primary/50 ring-primary/30",
+                )}
+              >
+                <img src={getIcon(card.answer)} alt={altLabel} className="size-full object-contain" draggable={false} />
+              </div>
+              <AnimatePresence>
+                {selected !== null && (
+                  <motion.div
+                    initial={{ opacity: 0, scale: 0.6 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.18, ease: "easeOut" }}
+                    className={cn(
+                      "absolute -top-2 -right-2 flex size-9 items-center justify-center rounded-full border-2 shadow-lg",
+                      selected === card.answer.id
+                        ? "border-green-400 bg-green-500 text-white"
+                        : "border-primary/70 bg-primary text-primary-foreground",
+                    )}
+                  >
+                    {selected === card.answer.id ? <Check className="size-5" /> : <X className="size-5" />}
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+
+            <div className="grid w-full grid-cols-1 gap-2 sm:grid-cols-2">
+              {card.options.map((option) => {
+                const isAnswer = option.id === card.answer.id;
+                const isPicked = option.id === selected;
+                const revealed = selected !== null;
+                return (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => handleChoice(option.id)}
+                    disabled={revealed}
+                    className={cn(
+                      "flex items-center justify-between border px-4 py-3 text-left font-mono text-sm font-medium tracking-wide uppercase transition-colors duration-150",
+                      !revealed &&
+                        "border-border bg-card hover:border-primary/50 hover:bg-primary/5 hover:text-primary",
+                      revealed && isAnswer && "border-green-500/60 bg-green-500/10 text-green-300",
+                      revealed && !isAnswer && isPicked && "border-primary/60 bg-primary/10 text-primary",
+                      revealed && !isAnswer && !isPicked && "border-border/50 bg-card/40 text-muted-foreground/60",
+                    )}
+                  >
+                    <span className="truncate">{option.name}</span>
+                    {revealed && isAnswer && <Check className="size-4 shrink-0 text-green-400" />}
+                    {revealed && !isAnswer && isPicked && <X className="size-4 shrink-0 text-primary" />}
+                  </button>
+                );
+              })}
+            </div>
+          </motion.div>
+        </AnimatePresence>
+      )}
+    </motion.div>
+  );
+}
+
+function Stat({ label, value, highlight }: { label: string; value: string; highlight?: boolean }) {
+  return (
+    <div className="flex items-baseline gap-1.5">
+      <span className="text-muted-foreground/50">{label}</span>
+      <span className={cn("font-semibold text-foreground", highlight && "text-primary")}>{value}</span>
+    </div>
+  );
+}
+
+function Divider() {
+  return <span className="text-muted-foreground/20">|</span>;
+}

--- a/website/app/routes/flashcards/components/FlashcardGame.tsx
+++ b/website/app/routes/flashcards/components/FlashcardGame.tsx
@@ -146,6 +146,7 @@ function FlashcardGameReady<T extends FlashcardEntry>({
   }, [pool]);
 
   const accuracy = stats.seen > 0 ? Math.round((stats.correct / stats.seen) * 100) : 0;
+  const empty = pool.length === 0;
   const exhausted = noRepeats && pool.length > 0 && seenIds.size >= pool.length;
 
   return (
@@ -208,7 +209,16 @@ function FlashcardGameReady<T extends FlashcardEntry>({
         </Label>
       </div>
 
-      {exhausted || !card ? (
+      {empty ? (
+        <motion.div
+          initial={{ opacity: 0, scale: 0.96 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.25, ease: "easeOut" }}
+          className="flex flex-col items-center gap-4 border border-border bg-card/40 px-6 py-12 text-center"
+        >
+          <p className="font-mono text-sm tracking-wider text-muted-foreground/70 uppercase">No cards available.</p>
+        </motion.div>
+      ) : exhausted || !card ? (
         <motion.div
           initial={{ opacity: 0, scale: 0.96 }}
           animate={{ opacity: 1, scale: 1 }}

--- a/website/app/routes/flashcards/components/FlashcardGame.tsx
+++ b/website/app/routes/flashcards/components/FlashcardGame.tsx
@@ -10,8 +10,8 @@ import { Label } from "~/components/ui/label";
 import { cn } from "~/lib/utils";
 
 const OPTION_COUNT = 4;
-const CORRECT_FEEDBACK_MS = 450;
-const WRONG_FEEDBACK_MS = 1800;
+const CORRECT_FEEDBACK_MS = 500;
+const WRONG_FEEDBACK_MS = 1500;
 
 export interface FlashcardEntry {
   id: number;
@@ -78,7 +78,9 @@ function FlashcardGameReady<T extends FlashcardEntry>({
   altLabel,
   completionLabel,
 }: FlashcardGameProps<T>) {
-  const [card, setCard] = useState<Card<T> | null>(() => (pool.length > 0 ? pickCard(pool, new Set()) : null));
+  const [card, setCard] = useState<Card<T> | null>(() =>
+    pool.length > 0 ? pickCard(pool, new Set()) : null,
+  );
   const [selected, setSelected] = useState<number | null>(null);
   const [stats, setStats] = useState({ correct: 0, seen: 0, streak: 0, bestStreak: 0 });
   const [seenIds, setSeenIds] = useState<Set<number>>(new Set());
@@ -215,7 +217,9 @@ function FlashcardGameReady<T extends FlashcardEntry>({
             <Check className="size-6" />
           </div>
           <div>
-            <p className="font-game text-xl tracking-tight text-foreground uppercase">{completionLabel}</p>
+            <p className="font-game text-xl tracking-tight text-foreground uppercase">
+              {completionLabel}
+            </p>
             <p className="mt-1 font-mono text-xs tracking-wider text-muted-foreground/60 uppercase">
               You got {stats.correct}/{stats.seen} correct ({accuracy}%)
             </p>
@@ -246,7 +250,12 @@ function FlashcardGameReady<T extends FlashcardEntry>({
                       : "border-primary/50 ring-primary/30",
                 )}
               >
-                <img src={getIcon(card.answer)} alt={altLabel} className="size-full object-contain" draggable={false} />
+                <img
+                  src={getIcon(card.answer)}
+                  alt={altLabel}
+                  className="size-full object-contain"
+                  draggable={false}
+                />
               </div>
               <AnimatePresence>
                 {selected !== null && (
@@ -262,7 +271,11 @@ function FlashcardGameReady<T extends FlashcardEntry>({
                         : "border-primary/70 bg-primary text-primary-foreground",
                     )}
                   >
-                    {selected === card.answer.id ? <Check className="size-5" /> : <X className="size-5" />}
+                    {selected === card.answer.id ? (
+                      <Check className="size-5" />
+                    ) : (
+                      <X className="size-5" />
+                    )}
                   </motion.div>
                 )}
               </AnimatePresence>
@@ -284,13 +297,21 @@ function FlashcardGameReady<T extends FlashcardEntry>({
                       !revealed &&
                         "border-border bg-card hover:border-primary/50 hover:bg-primary/5 hover:text-primary",
                       revealed && isAnswer && "border-green-500/60 bg-green-500/10 text-green-300",
-                      revealed && !isAnswer && isPicked && "border-primary/60 bg-primary/10 text-primary",
-                      revealed && !isAnswer && !isPicked && "border-border/50 bg-card/40 text-muted-foreground/60",
+                      revealed &&
+                        !isAnswer &&
+                        isPicked &&
+                        "border-primary/60 bg-primary/10 text-primary",
+                      revealed &&
+                        !isAnswer &&
+                        !isPicked &&
+                        "border-border/50 bg-card/40 text-muted-foreground/60",
                     )}
                   >
                     <span className="truncate">{option.name}</span>
                     {revealed && isAnswer && <Check className="size-4 shrink-0 text-green-400" />}
-                    {revealed && !isAnswer && isPicked && <X className="size-4 shrink-0 text-primary" />}
+                    {revealed && !isAnswer && isPicked && (
+                      <X className="size-4 shrink-0 text-primary" />
+                    )}
                   </button>
                 );
               })}
@@ -306,7 +327,9 @@ function Stat({ label, value, highlight }: { label: string; value: string; highl
   return (
     <div className="flex items-baseline gap-1.5">
       <span className="text-muted-foreground/50">{label}</span>
-      <span className={cn("font-semibold text-foreground", highlight && "text-primary")}>{value}</span>
+      <span className={cn("font-semibold text-foreground", highlight && "text-primary")}>
+        {value}
+      </span>
     </div>
   );
 }

--- a/website/app/routes/flashcards/components/FlashcardGame.tsx
+++ b/website/app/routes/flashcards/components/FlashcardGame.tsx
@@ -55,7 +55,7 @@ export interface FlashcardGameProps<T extends FlashcardEntry> {
   isLoading: boolean;
   storageKey: string;
   altLabel: string;
-  completionLabel: string;
+  masteredLabel: string;
 }
 
 export function FlashcardGame<T extends FlashcardEntry>(props: FlashcardGameProps<T>) {
@@ -76,7 +76,7 @@ function FlashcardGameReady<T extends FlashcardEntry>({
   getIcon,
   storageKey,
   altLabel,
-  completionLabel,
+  masteredLabel,
 }: FlashcardGameProps<T>) {
   const [card, setCard] = useState<Card<T> | null>(() => (pool.length > 0 ? pickCard(pool, new Set()) : null));
   const [selected, setSelected] = useState<number | null>(null);
@@ -198,7 +198,7 @@ function FlashcardGameReady<T extends FlashcardEntry>({
           <span>No repeats</span>
           {noRepeats && (
             <span className="text-muted-foreground/40 normal-case">
-              ({seenIds.size}/{pool.length} seen)
+              ({seenIds.size}/{pool.length} mastered)
             </span>
           )}
         </Label>
@@ -215,7 +215,7 @@ function FlashcardGameReady<T extends FlashcardEntry>({
             <Check className="size-6" />
           </div>
           <div>
-            <p className="font-game text-xl tracking-tight text-foreground uppercase">{completionLabel}</p>
+            <p className="font-game text-xl tracking-tight text-foreground uppercase">{masteredLabel}</p>
             <p className="mt-1 font-mono text-xs tracking-wider text-muted-foreground/60 uppercase">
               You got {stats.correct}/{stats.seen} correct ({accuracy}%)
             </p>

--- a/website/app/routes/flashcards/components/FlashcardGame.tsx
+++ b/website/app/routes/flashcards/components/FlashcardGame.tsx
@@ -66,7 +66,7 @@ export function FlashcardGame<T extends FlashcardEntry>(props: FlashcardGameProp
       </div>
     );
   }
-  return <FlashcardGameReady key={props.storageKey} {...props} />;
+  return <FlashcardGameReady {...props} />;
 }
 
 function FlashcardGameReady<T extends FlashcardEntry>({

--- a/website/app/routes/flashcards/components/FlashcardGame.tsx
+++ b/website/app/routes/flashcards/components/FlashcardGame.tsx
@@ -87,8 +87,12 @@ function FlashcardGameReady<T extends FlashcardEntry>({
     return localStorage.getItem(storageKey) === "true";
   });
   const advanceTimer = useRef<number | null>(null);
+  // Mirrors `noRepeats` so the 450–1800ms feedback-delay timer reads the toggle's current value at fire
+  // time; keeping `noRepeats` out of `handleChoice`'s deps avoids ignoring mid-delay toggles.
+  // Writes flow exclusively through `updateNoRepeats` — never mirrored during render.
   const noRepeatsRef = useRef(noRepeats);
 
+  // Single write path for both the `noRepeats` state and `noRepeatsRef`.
   const updateNoRepeats = useCallback(
     (value: boolean) => {
       noRepeatsRef.current = value;

--- a/website/app/routes/flashcards/components/FlashcardGame.tsx
+++ b/website/app/routes/flashcards/components/FlashcardGame.tsx
@@ -6,6 +6,7 @@ import { Link } from "react-router";
 import { LoadingLogo } from "~/components/LoadingLogo";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
+import { Label } from "~/components/ui/label";
 import { cn } from "~/lib/utils";
 
 const OPTION_COUNT = 4;
@@ -183,15 +184,22 @@ function FlashcardGameReady<T extends FlashcardEntry>({
       </div>
 
       <div className="mb-6 flex flex-wrap items-center justify-between gap-3 px-1 font-mono text-xs tracking-wider uppercase">
-        <label className="flex cursor-pointer items-center gap-2 text-muted-foreground/70 hover:text-foreground">
-          <Checkbox checked={noRepeats} onCheckedChange={(v) => updateNoRepeats(v === true)} />
+        <Label
+          htmlFor="flashcard-no-repeats"
+          className="flex cursor-pointer items-center gap-2 text-muted-foreground/70 hover:text-foreground"
+        >
+          <Checkbox
+            id="flashcard-no-repeats"
+            checked={noRepeats}
+            onCheckedChange={(v) => updateNoRepeats(v === true)}
+          />
           <span>No repeats</span>
           {noRepeats && (
             <span className="text-muted-foreground/40 normal-case">
               ({seenIds.size}/{pool.length} seen)
             </span>
           )}
-        </label>
+        </Label>
       </div>
 
       {exhausted || !card ? (

--- a/website/app/routes/flashcards/components/FlashcardGame.tsx
+++ b/website/app/routes/flashcards/components/FlashcardGame.tsx
@@ -78,9 +78,7 @@ function FlashcardGameReady<T extends FlashcardEntry>({
   altLabel,
   completionLabel,
 }: FlashcardGameProps<T>) {
-  const [card, setCard] = useState<Card<T> | null>(() =>
-    pool.length > 0 ? pickCard(pool, new Set()) : null,
-  );
+  const [card, setCard] = useState<Card<T> | null>(() => (pool.length > 0 ? pickCard(pool, new Set()) : null));
   const [selected, setSelected] = useState<number | null>(null);
   const [stats, setStats] = useState({ correct: 0, seen: 0, streak: 0, bestStreak: 0 });
   const [seenIds, setSeenIds] = useState<Set<number>>(new Set());
@@ -217,9 +215,7 @@ function FlashcardGameReady<T extends FlashcardEntry>({
             <Check className="size-6" />
           </div>
           <div>
-            <p className="font-game text-xl tracking-tight text-foreground uppercase">
-              {completionLabel}
-            </p>
+            <p className="font-game text-xl tracking-tight text-foreground uppercase">{completionLabel}</p>
             <p className="mt-1 font-mono text-xs tracking-wider text-muted-foreground/60 uppercase">
               You got {stats.correct}/{stats.seen} correct ({accuracy}%)
             </p>
@@ -250,12 +246,7 @@ function FlashcardGameReady<T extends FlashcardEntry>({
                       : "border-primary/50 ring-primary/30",
                 )}
               >
-                <img
-                  src={getIcon(card.answer)}
-                  alt={altLabel}
-                  className="size-full object-contain"
-                  draggable={false}
-                />
+                <img src={getIcon(card.answer)} alt={altLabel} className="size-full object-contain" draggable={false} />
               </div>
               <AnimatePresence>
                 {selected !== null && (
@@ -271,11 +262,7 @@ function FlashcardGameReady<T extends FlashcardEntry>({
                         : "border-primary/70 bg-primary text-primary-foreground",
                     )}
                   >
-                    {selected === card.answer.id ? (
-                      <Check className="size-5" />
-                    ) : (
-                      <X className="size-5" />
-                    )}
+                    {selected === card.answer.id ? <Check className="size-5" /> : <X className="size-5" />}
                   </motion.div>
                 )}
               </AnimatePresence>
@@ -297,21 +284,13 @@ function FlashcardGameReady<T extends FlashcardEntry>({
                       !revealed &&
                         "border-border bg-card hover:border-primary/50 hover:bg-primary/5 hover:text-primary",
                       revealed && isAnswer && "border-green-500/60 bg-green-500/10 text-green-300",
-                      revealed &&
-                        !isAnswer &&
-                        isPicked &&
-                        "border-primary/60 bg-primary/10 text-primary",
-                      revealed &&
-                        !isAnswer &&
-                        !isPicked &&
-                        "border-border/50 bg-card/40 text-muted-foreground/60",
+                      revealed && !isAnswer && isPicked && "border-primary/60 bg-primary/10 text-primary",
+                      revealed && !isAnswer && !isPicked && "border-border/50 bg-card/40 text-muted-foreground/60",
                     )}
                   >
                     <span className="truncate">{option.name}</span>
                     {revealed && isAnswer && <Check className="size-4 shrink-0 text-green-400" />}
-                    {revealed && !isAnswer && isPicked && (
-                      <X className="size-4 shrink-0 text-primary" />
-                    )}
+                    {revealed && !isAnswer && isPicked && <X className="size-4 shrink-0 text-primary" />}
                   </button>
                 );
               })}
@@ -327,9 +306,7 @@ function Stat({ label, value, highlight }: { label: string; value: string; highl
   return (
     <div className="flex items-baseline gap-1.5">
       <span className="text-muted-foreground/50">{label}</span>
-      <span className={cn("font-semibold text-foreground", highlight && "text-primary")}>
-        {value}
-      </span>
+      <span className={cn("font-semibold text-foreground", highlight && "text-primary")}>{value}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Description
Adds a `/flashcards` page with two drill modes — heroes and items — so players can learn Deadlock's icons by name. Icons appear everywhere (match history, streams, build guides) but there was nowhere on the site to practice associating them with names.

Each card shows an icon and four name choices. Correct answers advance quickly; wrong answers linger on the correct option so the mistake sticks. An opt-in "no repeats" mode (stored in `localStorage`) drops seen entries from the pool until the deck is exhausted, useful for grinding through the full hero or item roster.

Both routes share a generic `FlashcardGame` component parameterized by the entry type, icon accessor, and storage key, so future decks (abilities, patches, etc.) are thin wrappers. The hub is linked from the sidebar's Games group next to Deadlockdle.

## Related Issue
N/A

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring (no functional changes)
- [ ] Other (please describe):

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

<img width="1097" height="1291" alt="flashcards-tiles" src="https://github.com/user-attachments/assets/2e440d5c-7f6a-4b69-9507-bf2477d90233" />
<img width="1097" height="1291" alt="hero-flashcards" src="https://github.com/user-attachments/assets/57b3f52b-db94-46ff-a3b1-8ecb5eeb8077" />
<img width="1097" height="1291" alt="item-flashcards" src="https://github.com/user-attachments/assets/899d40c0-80be-42df-84fe-caafa7bed3c9" />

## Additional Notes
N/A