### PR TITLE
ci: add least-privilege permissions to rust-ci-checks workflow

### DIFF
--- a/.github/workflows/rust-ci-checks.yml
+++ b/.github/workflows/rust-ci-checks.yml
@@ -27,6 +27,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   fmt:
     name: Format


### PR DESCRIPTION
## Summary

Resolves CodeQL alerts #9, #10, #11, #12 ("Workflow does not contain permissions").

- Adds a top-level `permissions: contents: read` block to `.github/workflows/rust-ci-checks.yml`
- Covers all four flagged jobs: `fmt` (line 32), `deps` (line 44), `typos` (line 58), `lint` (line 72)
- No write scopes are needed — all jobs only check out source and run static analysis

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3BH5VT1rhNe2vj7GJ6cJZ)_