### PR TITLE
build(docker): use cargo-sonic for CPU-dispatched fat binaries on amd64

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,34 +1,21 @@
 ARG EXE_NAME=deadlock-api-rust
-ARG CARGO_SONIC_VERSION=0.1.4
-ARG CARGO_SONIC_TARGET_CPUS=x86-64-v3,x86-64-v4,znver4
 
 FROM rust:1.95-slim-trixie AS builder
 ARG EXE_NAME
-ARG CARGO_SONIC_VERSION
-ARG CARGO_SONIC_TARGET_CPUS
 RUN apt-get update \
     && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev ca-certificates gcc libssl-dev pkg-config cmake build-essential clang curl mold \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-
-# Install cargo-sonic for building Linux CPU-dispatched fat binaries.
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    cargo install --locked cargo-sonic@${CARGO_SONIC_VERSION}
-
+# Tune codegen for the deploy host (AMD EPYC 7502P, Zen 2). Includes the mold
+# linker flag from .cargo/config.toml because RUSTFLAGS replaces, not extends,
+# the target.cfg rustflags from cargo config.
+ENV RUSTFLAGS="-Clink-arg=-fuse-ld=/usr/bin/mold -Ctarget-cpu=znver2"
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target,sharing=locked \
-    ARCH="$(dpkg --print-architecture)" \
-    && case "$ARCH" in \
-         amd64) \
-           cargo sonic --target-cpus="${CARGO_SONIC_TARGET_CPUS}" build --release --bin ${EXE_NAME} \
-           && cp /app/target/sonic/*/release/${EXE_NAME} /usr/local/bin/${EXE_NAME} ;; \
-         *) \
-           cargo build --release --bin ${EXE_NAME} \
-           && cp /app/target/release/${EXE_NAME} /usr/local/bin/${EXE_NAME} ;; \
-       esac
+    cargo build --release --bin ${EXE_NAME} \
+    && cp /app/target/release/${EXE_NAME} /usr/local/bin/${EXE_NAME}
 
 # We do not need the Rust toolchain to run the binary!
 FROM debian:trixie-slim AS runtime

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,17 +1,34 @@
 ARG EXE_NAME=deadlock-api-rust
+ARG CARGO_SONIC_VERSION=0.1.4
+ARG CARGO_SONIC_TARGET_CPUS=x86-64-v3,x86-64-v4,znver4
 
 FROM rust:1.95-slim-trixie AS builder
 ARG EXE_NAME
+ARG CARGO_SONIC_VERSION
+ARG CARGO_SONIC_TARGET_CPUS
 RUN apt-get update \
     && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev ca-certificates gcc libssl-dev pkg-config cmake build-essential clang curl mold \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
+
+# Install cargo-sonic for building Linux CPU-dispatched fat binaries.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo install --locked cargo-sonic@${CARGO_SONIC_VERSION}
+
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target,sharing=locked \
-    cargo build --release --bin ${EXE_NAME} \
-    && cp /app/target/release/${EXE_NAME} /usr/local/bin/${EXE_NAME}
+    ARCH="$(dpkg --print-architecture)" \
+    && case "$ARCH" in \
+         amd64) \
+           cargo sonic --target-cpus="${CARGO_SONIC_TARGET_CPUS}" build --release --bin ${EXE_NAME} \
+           && cp /app/target/sonic/*/release/${EXE_NAME} /usr/local/bin/${EXE_NAME} ;; \
+         *) \
+           cargo build --release --bin ${EXE_NAME} \
+           && cp /app/target/release/${EXE_NAME} /usr/local/bin/${EXE_NAME} ;; \
+       esac
 
 # We do not need the Rust toolchain to run the binary!
 FROM debian:trixie-slim AS runtime

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,34 +1,20 @@
-ARG CARGO_SONIC_VERSION=0.1.4
-ARG CARGO_SONIC_TARGET_CPUS=x86-64-v3,x86-64-v4,znver4
-
 FROM rust:1.95-slim-trixie AS builder
-ARG CARGO_SONIC_VERSION
-ARG CARGO_SONIC_TARGET_CPUS
 RUN apt-get update \
     && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev ca-certificates gcc libssl-dev pkg-config cmake build-essential clang curl git mold \
     && rm -rf /var/lib/apt/lists/*
 ENV SQLX_OFFLINE=true
 WORKDIR /app
-
-# Install cargo-sonic for building Linux CPU-dispatched fat binaries.
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    --mount=type=cache,target=/usr/local/cargo/git \
-    cargo install --locked cargo-sonic@${CARGO_SONIC_VERSION}
-
+# Tune codegen for the deploy host (AMD EPYC 7502P, Zen 2). Includes the mold
+# linker flag from .cargo/config.toml because RUSTFLAGS replaces, not extends,
+# the target.cfg rustflags from cargo config.
+ENV RUSTFLAGS="-Clink-arg=-fuse-ld=/usr/bin/mold -Ctarget-cpu=znver2"
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target,sharing=locked \
-    ARCH="$(dpkg --print-architecture)" \
+    cargo build --release --all-features \
     && mkdir -p /tmp/release-bin \
-    && case "$ARCH" in \
-         amd64) \
-           cargo sonic --target-cpus="${CARGO_SONIC_TARGET_CPUS}" build --release --all-features \
-           && find /app/target/sonic/*/release -maxdepth 1 -type f -executable -exec cp {} /tmp/release-bin/ \; ;; \
-         *) \
-           cargo build --release --all-features \
-           && find /app/target/release -maxdepth 1 -type f -executable -exec cp {} /tmp/release-bin/ \; ;; \
-       esac
+    && find /app/target/release -maxdepth 1 -type f -executable -exec cp {} /tmp/release-bin/ \;
 
 # We do not need the Rust toolchain to run the binary!
 FROM debian:trixie-slim AS runtime

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,16 +1,34 @@
+ARG CARGO_SONIC_VERSION=0.1.4
+ARG CARGO_SONIC_TARGET_CPUS=x86-64-v3,x86-64-v4,znver4
+
 FROM rust:1.95-slim-trixie AS builder
+ARG CARGO_SONIC_VERSION
+ARG CARGO_SONIC_TARGET_CPUS
 RUN apt-get update \
     && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev ca-certificates gcc libssl-dev pkg-config cmake build-essential clang curl git mold \
     && rm -rf /var/lib/apt/lists/*
 ENV SQLX_OFFLINE=true
 WORKDIR /app
+
+# Install cargo-sonic for building Linux CPU-dispatched fat binaries.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo install --locked cargo-sonic@${CARGO_SONIC_VERSION}
+
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target,sharing=locked \
-    cargo build --release --all-features \
+    ARCH="$(dpkg --print-architecture)" \
     && mkdir -p /tmp/release-bin \
-    && find /app/target/release -maxdepth 1 -type f -executable -exec cp {} /tmp/release-bin/ \;
+    && case "$ARCH" in \
+         amd64) \
+           cargo sonic --target-cpus="${CARGO_SONIC_TARGET_CPUS}" build --release --all-features \
+           && find /app/target/sonic/*/release -maxdepth 1 -type f -executable -exec cp {} /tmp/release-bin/ \; ;; \
+         *) \
+           cargo build --release --all-features \
+           && find /app/target/release -maxdepth 1 -type f -executable -exec cp {} /tmp/release-bin/ \; ;; \
+       esac
 
 # We do not need the Rust toolchain to run the binary!
 FROM debian:trixie-slim AS runtime


### PR DESCRIPTION
Build the API and tools images with cargo-sonic so the produced Linux
binaries embed multiple CPU-optimized payloads (x86-64-v3, x86-64-v4,
znver4) and dispatch to the best-matching one at runtime, falling back
to a generic build. Non-amd64 architectures keep the previous plain
`cargo build --release` path.

https://claude.ai/code/session_01DnNFUGTCedzjUxvr4xGyRK