### PR TITLE
fix(website): route streamkit widget URLs through SSR Worker

### DIFF
--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -8,7 +8,8 @@
     "directory": "./dist/client",
     "binding": "ASSETS",
     "not_found_handling": "404-page",
-    "html_handling": "drop-trailing-slash"
+    "html_handling": "drop-trailing-slash",
+    "run_worker_first": ["/streamkit/widgets/*"]
   },
   "routes": [
     { "pattern": "deadlock-api.com", "custom_domain": true },


### PR DESCRIPTION
## Summary

Fixes 404 errors on streamkit widget URLs like `/streamkit/widgets/SAmerica/1307778067/box`.

## Root cause

Widget URLs are dynamic per-user (region + accountId + widgetType in the path) and are constructed client-side in `widget-url.ts`. They aren't reachable via any prerendered link, so TanStack Start's `crawlLinks` prerenderer never produces a static HTML file for them in `dist/client/`.

In `wrangler.jsonc`, `assets.not_found_handling: "404-page"` tells Cloudflare's static asset binding to serve a 404 page whenever no asset matches — **without invoking the SSR Worker**. So every widget URL hits the asset layer, finds nothing, and gets the static 404 response. The recent fix in 2819128 (move `streamkit.tsx` to `streamkit/index.tsx` so widgets aren't nested under the builder layout) addressed an SSR-time crash inside the Worker, but the Worker was never being invoked for these URLs in the first place.

A previous attempt (9ed28c3) flipped `not_found_handling` to `"none"` to send every unmatched path to the Worker, but that was reverted (presumably because it makes every typo'd URL pay the SSR cost).

## Fix

Use Cloudflare's `run_worker_first` glob to send only `/streamkit/widgets/*` requests to the SSR Worker, leaving the cheap static 404 behavior in place for every other unmatched path.

```jsonc
"run_worker_first": ["/streamkit/widgets/*"]
```

## Test plan

- [ ] After deploy, hit `https://deadlock-api.com/streamkit/widgets/SAmerica/1307778067/box?vars=…` and verify it returns 200 with the widget HTML instead of 404
- [ ] Verify other dynamic-data routes (`/heroes`, `/items`, etc.) still work (they're prerendered, so unaffected)
- [ ] Verify a genuinely missing path (e.g. `/does-not-exist`) still returns the static 404 page (Worker not invoked)
- [ ] Confirm OBS / streaming overlay use of the widget URL renders correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcSMZMjPH4P6WFZdeeDRc2)_