### PR TITLE
fix: stop CORS Vary:origin from fragmenting Cloudflare cache

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -36,7 +36,6 @@ pub use error::*;
 use tower::limit::ConcurrencyLimitLayer;
 use tower_http::compression::predicate::NotForContentType;
 use tower_http::compression::{CompressionLayer, DefaultPredicate, Predicate};
-use tower_http::cors::CorsLayer;
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::normalize_path::{NormalizePath, NormalizePathLayer};
 use tower_http::trace::TraceLayer;
@@ -144,7 +143,6 @@ pub async fn router(port: u16) -> Result<NormalizePath<Router>, StartupError> {
             CacheControlMiddleware::new(Duration::from_secs(DEFAULT_CACHE_TIME))
                 .with_stale_while_revalidate(Duration::from_secs(DEFAULT_CACHE_TIME)),
         )
-        .layer(CorsLayer::very_permissive())
         .layer(CompressionLayer::new().compress_when(DefaultPredicate::new().and(NotForContentType::new("text/event-stream"))))
         .layer(RequestBodyLimitLayer::new(10 * 1024 * 1024)) // 10MB limit
         .layer(ConcurrencyLimitLayer::new(1000))

--- a/api/src/middleware/cors.rs
+++ b/api/src/middleware/cors.rs
@@ -1,0 +1,20 @@
+use axum::http::HeaderName;
+use tower_http::cors::{AllowHeaders, Any, CorsLayer};
+
+/// Wildcard-origin CORS with no `Vary` header, so public responses stay
+/// CDN-cacheable. Request headers are mirrored so header-based auth keeps
+/// working; cookies are not allowed.
+pub(crate) fn public() -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(AllowHeaders::mirror_request())
+        .expose_headers(Any)
+        .vary(Vec::<HeaderName>::new())
+}
+
+/// Origin-reflecting CORS that allows credentials (cookies). Forces
+/// `Vary: origin`, so only use it on routes that send `private`/`no-store`.
+pub(crate) fn credentialed() -> CorsLayer {
+    CorsLayer::very_permissive()
+}

--- a/api/src/middleware/mod.rs
+++ b/api/src/middleware/mod.rs
@@ -1,6 +1,7 @@
 pub(super) mod api_key;
 pub(super) mod cache;
 pub(super) mod cache_bust;
+pub(super) mod cors;
 pub(super) mod feature_flags;
 pub(super) mod rate_limit;
 pub(super) mod track_requests;

--- a/api/src/routes/mod.rs
+++ b/api/src/routes/mod.rs
@@ -2,6 +2,7 @@ use axum::routing::{get, post};
 use utoipa_axum::router::OpenApiRouter;
 
 use crate::context::AppState;
+use crate::middleware::cors;
 use crate::routes::v1::analytics::{
     badge_distribution, hero_comb_stats, hero_stats, item_stats, player_scoreboard,
 };
@@ -48,6 +49,7 @@ pub(super) fn router(state: &AppState) -> OpenApiRouter<AppState> {
             "/v1/players/scoreboard",
             get(player_scoreboard::player_scoreboard),
         )
-        .nest("/v1", v1::router(state))
         .nest("/v2", v2::router())
+        .layer(cors::public())
+        .nest("/v1", v1::router(state))
 }

--- a/api/src/routes/v1/assets/mod.rs
+++ b/api/src/routes/v1/assets/mod.rs
@@ -38,8 +38,8 @@ pub(super) fn router() -> OpenApiRouter<AppState> {
         .nest("/ranks", ranks::router())
         .nest("/steam-info", steam_info::router())
         .layer(
-            CacheControlMiddleware::new(Duration::from_mins(15))
-                .with_stale_while_revalidate(Duration::from_mins(15))
-                .with_stale_if_error(Duration::from_hours(24)),
+            CacheControlMiddleware::new(Duration::from_hours(1))
+                .with_stale_while_revalidate(Duration::from_hours(2))
+                .with_stale_if_error(Duration::from_hours(48)),
         )
 }

--- a/api/src/routes/v1/mod.rs
+++ b/api/src/routes/v1/mod.rs
@@ -1,6 +1,7 @@
 use utoipa_axum::router::OpenApiRouter;
 
 use crate::context::AppState;
+use crate::middleware::cors;
 
 pub mod analytics;
 mod assets;
@@ -19,6 +20,11 @@ pub(crate) mod servers;
 pub mod sql;
 
 pub(super) fn router(state: &AppState) -> OpenApiRouter<AppState> {
+    let credentialed = OpenApiRouter::new()
+        .nest("/auth", auth::router())
+        .nest("/patron", patron::router())
+        .layer(cors::credentialed());
+
     OpenApiRouter::new()
         .nest("/matches", matches::router())
         .nest("/players", players::router())
@@ -29,9 +35,9 @@ pub(super) fn router(state: &AppState) -> OpenApiRouter<AppState> {
         .nest("/commands", commands::router())
         .nest("/info", info::router())
         .nest("/sql", sql::router())
-        .nest("/auth", auth::router())
-        .nest("/patron", patron::router())
         .nest("/servers", servers::router())
         .nest("/assets", assets::router())
         .merge(graphql::router())
+        .layer(cors::public())
+        .merge(credentialed)
 }


### PR DESCRIPTION
## Problem

Public asset endpoints (`/v1/assets/*`) were leaking ~10 req/s to the origin despite returning `public, max-age=...`. Cloudflare *was* caching them, but the global `CorsLayer::very_permissive()` reflected the request `Origin` and emitted:

```
vary: origin, access-control-request-method, access-control-request-headers, accept-encoding
```

Cloudflare honors `Vary`, so it kept a **separate cache entry per distinct `Origin`**. Traffic is dominated by the Tauri desktop app (`tauri-plugin-http`) and browsers, which each send their own origin (`tauri://localhost`, `http://tauri.localhost`, `https://deadlock-api.com`, ...), so no bucket stayed warm.

Verified live:

| Origin sent | CF-Cache-Status |
|---|---|
| *(none)* | HIT |
| `https://deadlock-api.com` | MISS |
| `tauri://localhost` | MISS |
| `http://tauri.localhost` | MISS |

## Fix

CORS is now applied per route group instead of one global layer:

- **`cors::public()`** — wildcard `Access-Control-Allow-Origin: *`, no `Vary`, no credentials. Used for all public/cacheable routes so Cloudflare keeps a single entry per URL. Request headers are mirrored so header-based auth (`X-API-Key`, `Authorization`) still works cross-origin.
- **`cors::credentialed()`** — origin-reflecting `very_permissive` (cookies). Scoped to `/v1/auth` and `/v1/patron` only. These send `private`/`no-store` and are never cached, so their per-origin `Vary` costs nothing.

The website's data SDK (axios) sends non-credentialed requests; only `/v1/auth/*` and `/v1/patron/*` use `credentials: "include"`, so this split is safe.

The credentialed group is `merge`d **after** the `cors::public()` layer so it is not wrapped/clobbered by it.

Also bumps the assets cache: `max-age=1h`, `stale-while-revalidate=2h`, `stale-if-error=2d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)