### PR TITLE
chore(deps): update dependencies and migrate cached 1.1 → 2.0

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -521,9 +521,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.1"
+version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+checksum = "b2f04f6fef12d70d42a77b1433c9e0f065238479a6cefc4f5bab105e9873a3c3"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -647,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.9.1"
+version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+checksum = "7d0bd4c2f75335ad98052a37efb54f428b492f64340257143b3429c8a508fa7b"
 dependencies = [
  "darling 0.23.0",
  "ident_case",
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -731,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "1.1.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4863037a22757575c62f4f52c71bc833c7989c696c35eda5c83a4f36599b2bbd"
+checksum = "dc0df7748fe2f601e376916ab19e7bfc2c74461b8abe3bce2ce20036ad8de38f"
 dependencies = [
  "ahash",
  "cached_proc_macro",
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "cached_proc_macro"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a89b3ceb2f9166826b0d21b670a8720dbaeb3397428d1c7603e0ffacdfd37"
+checksum = "66e734c52502e6cf54dce2ba07108906b04b8fe57f4f5e3ef7d58267b4abf060"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -766,9 +766,9 @@ checksum = "26cf465651fa6ad902a2d327ba60c3a6bc61c6a2f4ad70d091cf20dfda0074ef"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -879,7 +879,7 @@ dependencies = [
 [[package]]
 name = "clickhouse-sql-parser"
 version = "0.1.0"
-source = "git+https://github.com/raimannma/clickhouse-antlr4#5c7b7e92bde2878b1c135e144c6a75961b54118c"
+source = "git+https://github.com/raimannma/clickhouse-antlr4#32369a3ade8a0426a40d37dd2dc7352d73941b70"
 dependencies = [
  "antlr4rust",
 ]
@@ -905,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "combine"
@@ -1430,7 +1430,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -1438,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2050,9 +2050,9 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2139,9 +2139,9 @@ checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2199,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2476,9 +2476,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -2578,13 +2578,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2703,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
@@ -2806,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
@@ -2892,9 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3079,9 +3078,9 @@ dependencies = [
 
 [[package]]
 name = "num-modular"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+checksum = "b8d1aedba5cebbd8d4e97e7e71409b00c11e277e754d1a6701695e23ef6775d7"
 
 [[package]]
 name = "num-order"
@@ -3170,9 +3169,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.80"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3201,9 +3200,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.116"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -3752,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3762,9 +3761,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
  "itertools",
@@ -3781,9 +3780,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3794,9 +3793,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -4148,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4171,9 +4170,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -4395,9 +4394,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -4681,9 +4680,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -4701,9 +4700,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4766,9 +4765,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4859,9 +4858,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -4874,9 +4873,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5617,9 +5616,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -5866,9 +5865,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
@@ -6075,9 +6074,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6094,7 +6093,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "valveprotos"
 version = "0.0.0"
-source = "git+https://github.com/deadlock-api/valveprotos-rs.git?rev=63a9001f9bd1bb9095cc5c503ec3db80085f6bae#63a9001f9bd1bb9095cc5c503ec3db80085f6bae"
+source = "git+https://github.com/deadlock-api/valveprotos-rs.git?rev=d4ce19ea77083bdc4db690bbd906659f80f34be4#d4ce19ea77083bdc4db690bbd906659f80f34be4"
 dependencies = [
  "heck",
  "prost",
@@ -6154,9 +6153,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -6172,9 +6171,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6185,9 +6184,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6195,9 +6194,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6205,9 +6204,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6218,9 +6217,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -6274,9 +6273,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6700,9 +6699,9 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6723,18 +6722,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6764,18 +6763,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -18,8 +18,8 @@ tracing-opentelemetry = "0.33"
 redis = { version = "1.2.2", default-features = false, features = ["tokio-comp"] }
 clickhouse = { version = "0.15.1", features = ["chrono", "uuid"] }
 sqlx = { version = "0.9.0", features = ["chrono", "derive", "postgres", "runtime-tokio", "uuid"] }
-uuid = { version = "1.23.2", features = ["serde", "v4"] }
-cached = { version = "1.1", features = ["async", "serde"] }
+uuid = { version = "1.23.3", features = ["serde", "v4"] }
+cached = { version = "2.0", features = ["async", "serde"] }
 axum = "0.8.9"
 utoipa-axum = "0.2.0"
 utoipa = { version = "5.5.0", features = ["axum_extras", "chrono", "uuid"] }
@@ -37,8 +37,8 @@ axum-prometheus = "0.10.0"
 itertools = "0.14.0"
 futures = "0.3.32"
 snap = "1.1.1"
-valveprotos = { git = "https://github.com/deadlock-api/valveprotos-rs.git", rev = "63a9001f9bd1bb9095cc5c503ec3db80085f6bae", features = ["gc-client", "serde"] }
-prost = "0.14.3"
+valveprotos = { git = "https://github.com/deadlock-api/valveprotos-rs.git", rev = "d4ce19ea77083bdc4db690bbd906659f80f34be4", features = ["gc-client", "serde"] }
+prost = "0.14.4"
 base64 = "0.22.1"
 tryhard = "0.5.2"
 async-compression = { version = "0.4.42", features = ["bzip2", "zstd", "tokio"] }
@@ -53,7 +53,7 @@ thiserror = "2.0.18"
 rand = "0.10.1"
 quick-xml = { version = "0.40.1", features = ["serde", "serialize"] }
 serde-env = "0.3.0"
-regex = "1.12.3"
+regex = "1.12.4"
 memchr = "2"
 mimalloc = "0.1.52"
 urlencoding = "2.1.3"

--- a/api/src/routes/v1/analytics/ability_order_stats.rs
+++ b/api/src/routes/v1/analytics/ability_order_stats.rs
@@ -3,7 +3,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use serde::{Deserialize, Serialize};
@@ -173,9 +172,7 @@ fn build_query(query: &AbilityOrderStatsQuery) -> String {
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<AnalyticsAbilityOrderStats>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/game_stats.rs
+++ b/api/src/routes/v1/analytics/game_stats.rs
@@ -3,7 +3,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use serde::{Deserialize, Serialize};
@@ -220,9 +219,7 @@ fn build_query(query: &GameStatsQuery) -> String {
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<AnalyticsGameStats>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/hero_ban_stats.rs
+++ b/api/src/routes/v1/analytics/hero_ban_stats.rs
@@ -2,7 +2,6 @@ use axum::Json;
 use axum::extract::State;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use serde::{Deserialize, Serialize};
@@ -114,9 +113,7 @@ fn build_query(query: &HeroBanStatsQuery) -> String {
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<HeroBanStats>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/hero_build_stats.rs
+++ b/api/src/routes/v1/analytics/hero_build_stats.rs
@@ -2,7 +2,6 @@ use axum::Json;
 use axum::extract::{Path, State};
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use itertools::Itertools;
@@ -155,9 +154,7 @@ async fn fetch_valid_build_ids(pg_client: &Pool<Postgres>, hero_id: u32) -> sqlx
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<HeroBuildStats>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/hero_comb_stats.rs
+++ b/api/src/routes/v1/analytics/hero_comb_stats.rs
@@ -6,7 +6,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use itertools::Itertools;
@@ -281,9 +280,7 @@ SETTINGS log_comment = 'hero_comb_stats', apply_patch_parts = 0
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<HeroCombStats>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/hero_counters_stats.rs
+++ b/api/src/routes/v1/analytics/hero_counters_stats.rs
@@ -2,7 +2,6 @@ use axum::Json;
 use axum::extract::State;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use itertools::Itertools;
@@ -256,9 +255,7 @@ fn build_query(query: &HeroCounterStatsQuery) -> String {
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<HeroCounterStats>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/hero_scoreboard.rs
+++ b/api/src/routes/v1/analytics/hero_scoreboard.rs
@@ -3,7 +3,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use itertools::Itertools;
@@ -151,9 +150,7 @@ SETTINGS log_comment = 'hero_scoreboard', apply_patch_parts = 0
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<HeroEntry>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/hero_stats.rs
+++ b/api/src/routes/v1/analytics/hero_stats.rs
@@ -3,7 +3,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use serde::{Deserialize, Serialize};
@@ -456,9 +455,7 @@ fn build_query(query: &HeroStatsQuery) -> String {
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<AnalyticsHeroStats>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/hero_synergies_stats.rs
+++ b/api/src/routes/v1/analytics/hero_synergies_stats.rs
@@ -2,7 +2,6 @@ use axum::Json;
 use axum::extract::State;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use itertools::Itertools;
@@ -266,9 +265,7 @@ fn build_query(query: &HeroSynergyStatsQuery) -> String {
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<HeroSynergyStats>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/item_flow_stats.rs
+++ b/api/src/routes/v1/analytics/item_flow_stats.rs
@@ -3,7 +3,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use serde::{Deserialize, Serialize};
@@ -526,9 +525,7 @@ fn build_edges_query(query: &ItemFlowStatsQuery) -> String {
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<ItemFlowNode>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"
@@ -541,9 +538,7 @@ async fn run_nodes_query(
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<ItemFlowEdge>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"
@@ -580,9 +575,7 @@ struct ItemFlowTotalsRow {
 }
 
 #[cached(
-    ty = "TtlCache<String, ItemFlowTotalsRow>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/item_permutation_stats.rs
+++ b/api/src/routes/v1/analytics/item_permutation_stats.rs
@@ -3,7 +3,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use itertools::Itertools;
@@ -197,9 +196,7 @@ fn build_query(query: &ItemPermutationStatsQuery) -> String {
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<ItemPermutationStats>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/item_stats.rs
+++ b/api/src/routes/v1/analytics/item_stats.rs
@@ -5,7 +5,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use itertools::Itertools;
@@ -778,9 +777,7 @@ SETTINGS {settings_clause}
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<ItemStats>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/player_performance_curve.rs
+++ b/api/src/routes/v1/analytics/player_performance_curve.rs
@@ -3,7 +3,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use serde::{Deserialize, Serialize};
@@ -198,9 +197,7 @@ fn build_query(query: &PlayerPerformanceCurveQuery) -> String {
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<PlayerPerformanceCurvePoint>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/player_scoreboard.rs
+++ b/api/src/routes/v1/analytics/player_scoreboard.rs
@@ -3,7 +3,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use itertools::Itertools;
@@ -211,9 +210,7 @@ SETTINGS log_comment = 'player_scoreboard', apply_patch_parts = 0, do_not_merge_
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<PlayerEntry>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/analytics/player_stats_metrics.rs
+++ b/api/src/routes/v1/analytics/player_stats_metrics.rs
@@ -5,7 +5,6 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use itertools::Itertools;
@@ -522,9 +521,7 @@ fn build_query(query: &PlayerStatsMetricsQuery) -> String {
 }
 
 #[cached(
-    ty = "TtlCache<String, AnalyticsPlayerStatsMetricsRow>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60*60)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ query_str.to_string() }",
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/info/health.rs
+++ b/api/src/routes/v1/info/health.rs
@@ -1,7 +1,6 @@
 use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
-use cached::TtlCache;
 use cached::macros::cached;
 use redis::AsyncCommands;
 use serde::{Deserialize, Serialize};
@@ -35,18 +34,12 @@ pub struct Status {
     pub services: StatusServices,
 }
 
-#[cached(
-    ty = "TtlCache<u8, Status>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60)) }",
-    result = true,
-    convert = "{ 0 }",
-    sync_writes = "default"
-)]
+#[cached(ttl = 60, convert = "{ 0 }", key = "u8", sync_writes = "default")]
 async fn check_health(
     ch_client: clickhouse::Client,
     pg_client: Pool<Postgres>,
     redis_client: &mut redis::aio::MultiplexedConnection,
-) -> APIResult<Status> {
+) -> Result<Status, APIError> {
     let mut status = Status::default();
 
     // Check Clickhouse connection

--- a/api/src/routes/v1/leaderboard/route.rs
+++ b/api/src/routes/v1/leaderboard/route.rs
@@ -8,7 +8,6 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use futures::join;
@@ -28,7 +27,7 @@ use crate::routes::v1::leaderboard::types::{
 };
 use crate::services::steam::client::SteamClient;
 use crate::services::steam::types::{
-    SteamProxyQuery, SteamProxyRawResponse, SteamProxyResponse, SteamProxyResult,
+    SteamProxyError, SteamProxyQuery, SteamProxyRawResponse, SteamProxyResponse,
 };
 
 #[derive(Debug, Deserialize, IntoParams)]
@@ -50,9 +49,7 @@ pub(super) struct LeaderboardHeroQuery {
 }
 
 #[cached(
-    ty = "TtlCache<(LeaderboardRegion, Option<u32>), SteamProxyRawResponse>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(10 * 60)) }",
-    result = true,
+    ttl = 600,
     convert = "{ (region, hero_id) }",
     sync_writes = "by_key",
     key = "(LeaderboardRegion, Option<u32>)"
@@ -61,7 +58,7 @@ pub(crate) async fn fetch_leaderboard_raw(
     steam_client: &SteamClient,
     region: LeaderboardRegion,
     hero_id: Option<u32>,
-) -> SteamProxyResult<SteamProxyRawResponse> {
+) -> Result<SteamProxyRawResponse, SteamProxyError> {
     let msg = CMsgClientToGcGetLeaderboard {
         leaderboard_region: Some(region as i32),
         hero_id,
@@ -80,13 +77,7 @@ pub(crate) async fn fetch_leaderboard_raw(
         .await
 }
 
-#[cached(
-    ty = "TtlCache<u8, HashMap<String, Vec<u32>>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(24 * 60 * 60)) }",
-    result = true,
-    convert = "{ 0 }",
-    sync_writes = "default"
-)]
+#[cached(ttl = 86400, convert = "{ 0 }", key = "u8", sync_writes = "default")]
 async fn fetch_all_steam_names(
     ch_client: &clickhouse::Client,
 ) -> clickhouse::error::Result<HashMap<String, Vec<u32>>> {

--- a/api/src/routes/v1/matches/active.rs
+++ b/api/src/routes/v1/matches/active.rs
@@ -6,7 +6,6 @@ use axum::response::IntoResponse;
 use axum_extra::extract::Query;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
-use cached::TtlCache;
 use cached::macros::cached;
 use itertools::Itertools;
 use prost::Message;
@@ -35,14 +34,8 @@ pub(super) struct ActiveMatchesQuery {
     account_ids: Option<Vec<u32>>,
 }
 
-#[cached(
-    ty = "TtlCache<u8, Vec<u8>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60)) }",
-    result = true,
-    convert = "{ 0 }",
-    sync_writes = "default"
-)]
-async fn fetch_active_matches_raw(state: &AppState) -> APIResult<Vec<u8>> {
+#[cached(ttl = 60, convert = "{ 0 }", key = "u8", sync_writes = "default")]
+async fn fetch_active_matches_raw(state: &AppState) -> Result<Vec<u8>, APIError> {
     let steam_response = state
         .steam_client
         .call_steam_proxy_raw(SteamProxyQuery {

--- a/api/src/routes/v1/matches/live_url.rs
+++ b/api/src/routes/v1/matches/live_url.rs
@@ -4,7 +4,6 @@ use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use cached::TtlCache;
 use cached::macros::cached;
 use redis::{AsyncTypedCommands, ExpireOption};
 use serde::{Deserialize, Serialize};
@@ -58,9 +57,7 @@ pub(super) struct IngestLiveUrl {
 }
 
 #[cached(
-    ty = "TtlCache<u64, CMsgClientToGcSpectateLobbyResponse>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60)) }",
-    result = true,
+    ttl = 60,
     convert = "{ match_id }",
     sync_writes = "by_key",
     key = "u64"
@@ -68,7 +65,7 @@ pub(super) struct IngestLiveUrl {
 pub(super) async fn spectate_match(
     steam_client: &SteamClient,
     match_id: u64,
-) -> APIResult<CMsgClientToGcSpectateLobbyResponse> {
+) -> Result<CMsgClientToGcSpectateLobbyResponse, APIError> {
     let client_version = steam_client.get_current_client_version().await?;
     let msg = CMsgClientToGcSpectateLobby {
         match_id: Some(match_id),

--- a/api/src/routes/v1/matches/recently_fetched.rs
+++ b/api/src/routes/v1/matches/recently_fetched.rs
@@ -1,7 +1,6 @@
 use axum::Json;
 use axum::extract::State;
 use axum::response::IntoResponse;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use serde::{Deserialize, Serialize};
@@ -62,13 +61,7 @@ impl From<ClickhouseMatchInfoRow> for ClickhouseMatchInfo {
     }
 }
 
-#[cached(
-    ty = "TtlCache<u8, Vec<ClickhouseMatchInfo>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60)) }",
-    result = true,
-    convert = "{ 0 }",
-    sync_writes = "default"
-)]
+#[cached(ttl = 60, convert = "{ 0 }", key = "u8", sync_writes = "default")]
 async fn get_recently_fetched_match_ids(
     ch_client: &clickhouse::Client,
 ) -> clickhouse::error::Result<Vec<ClickhouseMatchInfo>> {

--- a/api/src/routes/v1/matches/salts.rs
+++ b/api/src/routes/v1/matches/salts.rs
@@ -5,7 +5,6 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use serde::{Deserialize, Serialize};
@@ -155,9 +154,7 @@ impl From<(u64, CMsgClientToGcGetMatchMetaDataResponse)> for MatchSaltsResponse 
 }
 
 #[cached(
-    ty = "TtlCache<u64, CMsgClientToGcGetMatchMetaDataResponse>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60)) }",
-    result = true,
+    ttl = 60,
     convert = "{ match_id }",
     sync_writes = "by_key",
     key = "u64"
@@ -168,7 +165,7 @@ pub(super) async fn fetch_match_salts(
     match_id: u64,
     is_custom: bool,
     disable_steam: bool,
-) -> APIResult<CMsgClientToGcGetMatchMetaDataResponse> {
+) -> Result<CMsgClientToGcGetMatchMetaDataResponse, APIError> {
     // Try fetch from Clickhouse via batcher
     if let Ok(salts) = state.batchers.match_salts_read.load(match_id).await {
         debug!("Match salts found in Clickhouse");

--- a/api/src/routes/v1/players/account_stats.rs
+++ b/api/src/routes/v1/players/account_stats.rs
@@ -3,7 +3,6 @@ use core::time::Duration;
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::response::IntoResponse;
-use cached::TtlCache;
 use cached::macros::cached;
 use serde::Serialize;
 use utoipa::ToSchema;
@@ -17,7 +16,7 @@ use crate::error::{APIError, APIResult};
 use crate::services::rate_limiter::extractor::RateLimitKey;
 use crate::services::steam::client::SteamClient;
 use crate::services::steam::types::{
-    SteamProxyQuery, SteamProxyRawResponse, SteamProxyResponse, SteamProxyResult,
+    SteamProxyError, SteamProxyQuery, SteamProxyRawResponse, SteamProxyResponse,
 };
 use crate::utils::types::AccountIdQuery;
 
@@ -60,9 +59,7 @@ impl From<CMsgAccountStats> for PlayerAccountStats {
 }
 
 #[cached(
-    ty = "TtlCache<u32, SteamProxyRawResponse>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60)) }",
-    result = true,
+    ttl = 60,
     convert = "{ account_id }",
     sync_writes = "by_key",
     key = "u32"
@@ -71,7 +68,7 @@ pub(crate) async fn fetch_player_account_stats_raw(
     steam_client: &SteamClient,
     account_id: u32,
     bot_username: String,
-) -> SteamProxyResult<SteamProxyRawResponse> {
+) -> Result<SteamProxyRawResponse, SteamProxyError> {
     let msg = CMsgClientToGcGetAccountStats {
         account_id: Some(account_id),
         dev_access_hint: None,
@@ -92,9 +89,7 @@ pub(crate) async fn fetch_player_account_stats_raw(
 }
 
 #[cached(
-    ty = "TtlCache<u32, PlayerAccountStats>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(5*60)) }",
-    result = true,
+    ttl = 300,
     convert = "{ account_id }",
     sync_writes = "by_key",
     key = "u32"
@@ -103,7 +98,7 @@ pub(crate) async fn get_player_account_stats(
     steam_client: &SteamClient,
     account_id: u32,
     bot_username: String,
-) -> APIResult<PlayerAccountStats> {
+) -> Result<PlayerAccountStats, APIError> {
     let raw_data = tryhard::retry_fn(|| {
         fetch_player_account_stats_raw(steam_client, account_id, bot_username.clone())
     })

--- a/api/src/routes/v1/players/card.rs
+++ b/api/src/routes/v1/players/card.rs
@@ -3,7 +3,6 @@ use core::time::Duration;
 use axum::Json;
 use axum::extract::{Path, State};
 use axum::response::IntoResponse;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use serde::Serialize;
@@ -19,7 +18,7 @@ use crate::error::APIResult;
 use crate::services::rate_limiter::extractor::RateLimitKey;
 use crate::services::steam::client::SteamClient;
 use crate::services::steam::types::{
-    SteamProxyQuery, SteamProxyRawResponse, SteamProxyResponse, SteamProxyResult,
+    SteamProxyError, SteamProxyQuery, SteamProxyRawResponse, SteamProxyResponse,
 };
 use crate::utils::types::AccountIdQuery;
 
@@ -145,9 +144,7 @@ impl From<&PlayerCard> for PlayerCardClickhouse {
 }
 
 #[cached(
-    ty = "TtlCache<u32, SteamProxyRawResponse>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_mins(5)) }",
-    result = true,
+    ttl = 300,
     convert = "{ account_id }",
     sync_writes = "by_key",
     key = "u32"
@@ -156,7 +153,7 @@ pub(crate) async fn fetch_player_card_raw(
     steam_client: &SteamClient,
     account_id: u32,
     bot_username: String,
-) -> SteamProxyResult<SteamProxyRawResponse> {
+) -> Result<SteamProxyRawResponse, SteamProxyError> {
     let msg = CMsgClientToGcGetProfileCard {
         account_id: Some(account_id),
         dev_access_hint: None,

--- a/api/src/routes/v1/players/match_history.rs
+++ b/api/src/routes/v1/players/match_history.rs
@@ -5,7 +5,6 @@ use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use clickhouse::Row;
 use itertools::{Itertools, chain};
@@ -206,9 +205,7 @@ async fn fetch_match_history_raw(
 }
 
 #[cached(
-    ty = "TtlCache<(u32, bool), PlayerMatchHistory>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(8 * 60)) }",
-    result = true,
+    ttl = 480,
     convert = "{ (account_id, force_refetch) }",
     sync_writes = "by_key",
     key = "(u32, bool)"
@@ -218,7 +215,7 @@ pub(crate) async fn fetch_steam_match_history(
     account_id: u32,
     force_refetch: bool,
     bot_username: Option<String>,
-) -> APIResult<PlayerMatchHistory> {
+) -> Result<PlayerMatchHistory, APIError> {
     debug!("Fetching match history from Steam for account_id {account_id}");
     let mut continue_cursor = None;
     let mut all_matches = vec![];

--- a/api/src/routes/v1/players/mmr/batch.rs
+++ b/api/src/routes/v1/players/mmr/batch.rs
@@ -3,7 +3,6 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use serde::Deserialize;
 use tracing::debug;
@@ -106,9 +105,7 @@ fn build_mmr_query_inner(
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<MMRHistory>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60)) }",
-    result = true,
+    ttl = 60,
     convert = r#"{ format!("{account_ids:?}-{max_match_id:?}") }"#,
     sync_writes = "by_key",
     key = "String"

--- a/api/src/routes/v1/sql/route.rs
+++ b/api/src/routes/v1/sql/route.rs
@@ -7,7 +7,6 @@ use axum::extract::{Path, State};
 use axum::http::{StatusCode, header};
 use axum::response::IntoResponse;
 use axum_extra::extract::Query;
-use cached::TtlCache;
 use cached::macros::cached;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -239,13 +238,7 @@ pub(super) async fn list_tables(
     Ok(Json(fetch_list_tables(&state.ch_client_restricted).await?))
 }
 
-#[cached(
-    ty = "TtlCache<u8, Vec<String>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60 * 60)) }",
-    result = true,
-    convert = "{ 0 }",
-    sync_writes = "default"
-)]
+#[cached(ttl = 3600, convert = "{ 0 }", key = "u8", sync_writes = "default")]
 async fn fetch_list_tables(
     ch_client: &clickhouse::Client,
 ) -> clickhouse::error::Result<Vec<String>> {
@@ -322,9 +315,7 @@ pub(super) async fn table_schema(
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<TableSchemaRow>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60 * 60)) }",
-    result = true,
+    ttl = 3600,
     convert = r#"{ format!("{table}") }"#,
     sync_writes = "by_key",
     key = "String"

--- a/api/src/services/assets/index.rs
+++ b/api/src/services/assets/index.rs
@@ -1,7 +1,4 @@
-use core::time::Duration;
-
 use bytes::Bytes;
-use cached::TtlCache;
 use cached::macros::cached;
 use object_store::aws::AmazonS3;
 use strum::IntoStaticStr;
@@ -20,10 +17,9 @@ pub(crate) enum IndexFolder {
 
 /// Fetch the cached JSON file-tree index for `folder`.
 #[cached(
-    ty = "TtlCache<&'static str, Bytes>",
-    create = "{ TtlCache::with_ttl(Duration::from_secs(60 * 60)) }",
+    ttl = 3600,
     convert = r#"{ <&str>::from(folder) }"#,
-    result = true,
+    key = "&'static str",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_index(

--- a/api/src/services/assets/versions/accolades.rs
+++ b/api/src/services/assets/versions/accolades.rs
@@ -3,15 +3,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use cached::LruTtlCache;
 use cached::macros::cached;
 use object_store::aws::AmazonS3;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::services::assets::versions::common::{
-    DEFAULT_CACHE_SIZE, DEFAULT_CACHE_TTL, build_from_kv3,
-};
+use crate::services::assets::versions::common::build_from_kv3;
 use crate::services::assets::versions::error::AssetsError;
 use crate::services::assets::versions::localization;
 use crate::services::assets::versions::store;
@@ -84,10 +81,10 @@ fn map_game_mode(raw: &str) -> String {
 // ----- Cached fetch -----
 
 #[cached(
-    ty = "LruTtlCache<(u32, String), Arc<Vec<Accolade>>>",
-    create = "{ LruTtlCache::builder().size(DEFAULT_CACHE_SIZE).ttl(DEFAULT_CACHE_TTL).build() }",
+    max_size = 64,
+    ttl = 86400,
     convert = r#"{ (version, language.to_owned()) }"#,
-    result = true,
+    key = "(u32, String)",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_accolades(

--- a/api/src/services/assets/versions/build_tags.rs
+++ b/api/src/services/assets/versions/build_tags.rs
@@ -3,15 +3,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use cached::LruTtlCache;
 use cached::macros::cached;
 use object_store::aws::AmazonS3;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::services::assets::versions::common::{
-    DEFAULT_CACHE_SIZE, DEFAULT_CACHE_TTL, SVGS_BASE_URL, entity_id,
-};
+use crate::services::assets::versions::common::{SVGS_BASE_URL, entity_id};
 use crate::services::assets::versions::error::AssetsError;
 use crate::services::assets::versions::localization;
 
@@ -44,10 +41,10 @@ pub(crate) fn build_build_tags(loc: &HashMap<String, String>) -> Vec<BuildTag> {
 }
 
 #[cached(
-    ty = "LruTtlCache<(u32, String), Arc<Vec<BuildTag>>>",
-    create = "{ LruTtlCache::builder().size(DEFAULT_CACHE_SIZE).ttl(DEFAULT_CACHE_TTL).build() }",
+    max_size = 64,
+    ttl = 86400,
     convert = r#"{ (version, language.to_owned()) }"#,
-    result = true,
+    key = "(u32, String)",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_build_tags(

--- a/api/src/services/assets/versions/colors.rs
+++ b/api/src/services/assets/versions/colors.rs
@@ -3,12 +3,10 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use cached::LruTtlCache;
 use cached::macros::cached;
 use object_store::aws::AmazonS3;
 
 use crate::services::assets::versions::common::Color;
-use crate::services::assets::versions::common::{DEFAULT_CACHE_SIZE, DEFAULT_CACHE_TTL};
 use crate::services::assets::versions::css;
 use crate::services::assets::versions::error::AssetsError;
 use crate::services::assets::versions::store;
@@ -20,10 +18,10 @@ pub(crate) fn build_colors(css_src: &str) -> BTreeMap<String, Color> {
 }
 
 #[cached(
-    ty = "LruTtlCache<u32, Arc<BTreeMap<String, Color>>>",
-    create = "{ LruTtlCache::builder().size(DEFAULT_CACHE_SIZE).ttl(DEFAULT_CACHE_TTL).build() }",
+    max_size = 64,
+    ttl = 86400,
     convert = r#"{ version }"#,
-    result = true,
+    key = "u32",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_colors(

--- a/api/src/services/assets/versions/common.rs
+++ b/api/src/services/assets/versions/common.rs
@@ -1,7 +1,5 @@
 //! Types shared between `/v1/assets/*` versioned-asset endpoints.
 
-use core::time::Duration;
-
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
@@ -9,11 +7,6 @@ use utoipa::ToSchema;
 
 use crate::services::assets::versions::error::AssetsError;
 use crate::utils::kv3;
-
-/// Default LRU capacity for per-version `fetch_*` caches.
-pub(crate) const DEFAULT_CACHE_SIZE: usize = 64;
-/// Default TTL for per-version `fetch_*` caches.
-pub(crate) const DEFAULT_CACHE_TTL: Duration = Duration::from_hours(24);
 
 /// Base URL for static images served from the assets bucket.
 pub(crate) const IMAGE_BASE_URL: &str =

--- a/api/src/services/assets/versions/generic_data.rs
+++ b/api/src/services/assets/versions/generic_data.rs
@@ -4,7 +4,6 @@
 
 use std::sync::Arc;
 
-use cached::LruTtlCache;
 use cached::macros::cached;
 use indexmap::IndexMap;
 use object_store::aws::AmazonS3;
@@ -13,7 +12,6 @@ use strum::{Display, EnumString, FromRepr};
 use utoipa::ToSchema;
 
 use crate::services::assets::versions::common::Color;
-use crate::services::assets::versions::common::{DEFAULT_CACHE_SIZE, DEFAULT_CACHE_TTL};
 use crate::services::assets::versions::error::AssetsError;
 use crate::services::assets::versions::store;
 use crate::utils::kv3;
@@ -809,10 +807,10 @@ fn street_brawl_out(r: RawStreetBrawl) -> StreetBrawl {
 }
 
 #[cached(
-    ty = "LruTtlCache<u32, Arc<GenericData>>",
-    create = "{ LruTtlCache::builder().size(DEFAULT_CACHE_SIZE).ttl(DEFAULT_CACHE_TTL).build() }",
+    max_size = 64,
+    ttl = 86400,
     convert = "{ version }",
-    result = true,
+    key = "u32",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_generic_data(

--- a/api/src/services/assets/versions/heroes.rs
+++ b/api/src/services/assets/versions/heroes.rs
@@ -1,10 +1,8 @@
-use core::time::Duration;
 use std::collections::HashMap;
 use std::collections::HashMap as StdMap;
 use std::sync::Arc;
 
 use async_graphql::{ComplexObject, Enum, Json, SimpleObject};
-use cached::LruTtlCache;
 use cached::macros::cached;
 use indexmap::IndexMap;
 use object_store::aws::AmazonS3;
@@ -1049,11 +1047,6 @@ fn parse_img_path(v: &str) -> Option<String> {
     }
 }
 
-const SOURCES_CACHE_SIZE: usize = 8;
-const BUILT_CACHE_SIZE: usize = 64;
-// Files in R2 are immutable per version, so the TTL only evicts cold entries.
-const CACHE_TTL: Duration = Duration::from_hours(24);
-
 #[derive(Clone)]
 struct ParsedSources {
     raw_root: Arc<IndexMap<String, serde_json::Value>>,
@@ -1062,10 +1055,10 @@ struct ParsedSources {
 }
 
 #[cached(
-    ty = "LruTtlCache<u32, ParsedSources>",
-    create = "{ LruTtlCache::builder().size(SOURCES_CACHE_SIZE).ttl(CACHE_TTL).build() }",
+    max_size = 8,
+    ttl = 86400,
     convert = "{ version }",
-    result = true,
+    key = "u32",
     sync_writes = "by_key"
 )]
 async fn parsed_version_sources(r2: &AmazonS3, version: u32) -> Result<ParsedSources, AssetsError> {
@@ -1110,10 +1103,10 @@ async fn fetch_optional_text(
 }
 
 #[cached(
-    ty = "LruTtlCache<(u32, String), Arc<Vec<Hero>>>",
-    create = "{ LruTtlCache::builder().size(BUILT_CACHE_SIZE).ttl(CACHE_TTL).build() }",
+    max_size = 64,
+    ttl = 86400,
     convert = r#"{ (version, language.to_owned()) }"#,
-    result = true,
+    key = "(u32, String)",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_heroes(

--- a/api/src/services/assets/versions/items/mod.rs
+++ b/api/src/services/assets/versions/items/mod.rs
@@ -16,10 +16,8 @@
     clippy::if_not_else
 )]
 
-use core::time::Duration;
 use std::sync::Arc;
 
-use cached::LruTtlCache;
 use cached::macros::cached;
 use object_store::aws::AmazonS3;
 
@@ -39,14 +37,11 @@ pub(crate) mod types;
 
 pub(crate) use types::Item;
 
-const CACHE_SIZE: usize = 32;
-const CACHE_TTL: Duration = Duration::from_hours(24);
-
 #[cached(
-    ty = "LruTtlCache<(u32, String), Arc<Vec<Item>>>",
-    create = "{ LruTtlCache::builder().size(CACHE_SIZE).ttl(CACHE_TTL).build() }",
+    max_size = 32,
+    ttl = 86400,
     convert = r#"{ (version, language.to_owned()) }"#,
-    result = true,
+    key = "(u32, String)",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_items(

--- a/api/src/services/assets/versions/items/svg.rs
+++ b/api/src/services/assets/versions/items/svg.rs
@@ -3,16 +3,12 @@
 //! `https://assets-bucket.deadlock-api.com/assets-api-res/icons/<name>` and
 //! cached in-process. Negative responses are cached too so we don't refetch.
 
-use core::time::Duration;
 use std::sync::{Arc, OnceLock};
 
-use cached::LruTtlCache;
 use cached::macros::cached;
 use regex::Regex;
 
 const ICONS_BASE_URL: &str = "https://assets-bucket.deadlock-api.com/assets-api-res/icons";
-const CACHE_SIZE: usize = 256;
-const CACHE_TTL: Duration = Duration::from_hours(24);
 
 fn http() -> &'static reqwest::Client {
     static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
@@ -20,9 +16,10 @@ fn http() -> &'static reqwest::Client {
 }
 
 #[cached(
-    ty = "LruTtlCache<String, Arc<Option<String>>>",
-    create = "{ LruTtlCache::builder().size(CACHE_SIZE).ttl(CACHE_TTL).build() }",
+    max_size = 256,
+    ttl = 86400,
     convert = r#"{ name.to_owned() }"#,
+    key = "String",
     sync_writes = "by_key"
 )]
 pub(super) async fn fetch_svg(name: &str) -> Arc<Option<String>> {

--- a/api/src/services/assets/versions/localization.rs
+++ b/api/src/services/assets/versions/localization.rs
@@ -3,11 +3,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use cached::LruTtlCache;
 use cached::macros::cached;
 use object_store::aws::AmazonS3;
 
-use crate::services::assets::versions::common::{DEFAULT_CACHE_SIZE, DEFAULT_CACHE_TTL};
 use crate::services::assets::versions::error::AssetsError;
 use crate::services::assets::versions::store;
 
@@ -20,10 +18,10 @@ pub(crate) fn localize(loc: &HashMap<String, String>, token: &str) -> String {
 
 /// Falls back to english when the requested language is missing.
 #[cached(
-    ty = "LruTtlCache<(u32, String), Arc<HashMap<String, String>>>",
-    create = "{ LruTtlCache::builder().size(DEFAULT_CACHE_SIZE).ttl(DEFAULT_CACHE_TTL).build() }",
+    max_size = 64,
+    ttl = 86400,
     convert = r#"{ (version, language.to_owned()) }"#,
-    result = true,
+    key = "(u32, String)",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_localization(

--- a/api/src/services/assets/versions/loot_tables.rs
+++ b/api/src/services/assets/versions/loot_tables.rs
@@ -1,15 +1,12 @@
 use std::sync::Arc;
 
-use cached::LruTtlCache;
 use cached::macros::cached;
 use indexmap::IndexMap;
 use object_store::aws::AmazonS3;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::services::assets::versions::common::{
-    DEFAULT_CACHE_SIZE, DEFAULT_CACHE_TTL, build_map_from_kv3,
-};
+use crate::services::assets::versions::common::build_map_from_kv3;
 use crate::services::assets::versions::error::AssetsError;
 use crate::services::assets::versions::store;
 
@@ -53,10 +50,10 @@ pub(crate) fn build_loot_tables(vdata: &str) -> Result<LootTables, AssetsError> 
 }
 
 #[cached(
-    ty = "LruTtlCache<u32, Arc<LootTables>>",
-    create = "{ LruTtlCache::builder().size(DEFAULT_CACHE_SIZE).ttl(DEFAULT_CACHE_TTL).build() }",
+    max_size = 64,
+    ttl = 86400,
     convert = r#"{ version }"#,
-    result = true,
+    key = "u32",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_loot_tables(

--- a/api/src/services/assets/versions/map/mod.rs
+++ b/api/src/services/assets/versions/map/mod.rs
@@ -9,7 +9,6 @@ mod geometry;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use cached::LruTtlCache;
 use cached::macros::cached;
 use indexmap::IndexMap;
 use object_store::aws::AmazonS3;
@@ -17,9 +16,7 @@ use serde::Serialize;
 use strum::{Display, EnumIter, EnumString, IntoEnumIterator};
 use utoipa::ToSchema;
 
-use crate::services::assets::versions::common::{
-    Color, DEFAULT_CACHE_SIZE, DEFAULT_CACHE_TTL, IMAGE_BASE_URL,
-};
+use crate::services::assets::versions::common::{Color, IMAGE_BASE_URL};
 use crate::services::assets::versions::css;
 use crate::services::assets::versions::error::AssetsError;
 use crate::services::assets::versions::store;
@@ -203,10 +200,10 @@ pub(crate) fn build_map(css: &str) -> Result<MapData, AssetsError> {
 }
 
 #[cached(
-    ty = "LruTtlCache<u32, Arc<MapData>>",
-    create = "{ LruTtlCache::builder().size(DEFAULT_CACHE_SIZE).ttl(DEFAULT_CACHE_TTL).build() }",
+    max_size = 64,
+    ttl = 86400,
     convert = r#"{ version }"#,
-    result = true,
+    key = "u32",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_map(r2: &AmazonS3, version: u32) -> Result<Arc<MapData>, AssetsError> {

--- a/api/src/services/assets/versions/misc_entities.rs
+++ b/api/src/services/assets/versions/misc_entities.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use cached::LruTtlCache;
 use cached::macros::cached;
 use object_store::aws::AmazonS3;
 use serde::{Deserialize, Serialize};
@@ -10,8 +9,7 @@ use strum::{Display, EnumString};
 use utoipa::ToSchema;
 
 use crate::services::assets::versions::common::{
-    Color, DEFAULT_CACHE_SIZE, DEFAULT_CACHE_TTL, Subclass, WrapSubclass, build_from_kv3,
-    entity_id, enum_str_serde,
+    Color, Subclass, WrapSubclass, build_from_kv3, entity_id, enum_str_serde,
 };
 use crate::services::assets::versions::error::AssetsError;
 use crate::services::assets::versions::store;
@@ -390,10 +388,10 @@ fn curve_or_float_out(r: RawCurveOrFloat) -> CurveOrFloat {
 // ----- Cached fetch -----
 
 #[cached(
-    ty = "LruTtlCache<u32, Arc<Vec<MiscEntity>>>",
-    create = "{ LruTtlCache::builder().size(DEFAULT_CACHE_SIZE).ttl(DEFAULT_CACHE_TTL).build() }",
+    max_size = 64,
+    ttl = 86400,
     convert = "{ version }",
-    result = true,
+    key = "u32",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_misc_entities(

--- a/api/src/services/assets/versions/npc_units.rs
+++ b/api/src/services/assets/versions/npc_units.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use cached::LruTtlCache;
 use cached::macros::cached;
 use indexmap::IndexMap;
 use object_store::aws::AmazonS3;
@@ -10,8 +9,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::services::assets::versions::common::{
-    Color, DEFAULT_CACHE_SIZE, DEFAULT_CACHE_TTL, HeroItemType, Subclass, WrapSubclass,
-    build_from_kv3, entity_id,
+    Color, HeroItemType, Subclass, WrapSubclass, build_from_kv3, entity_id,
 };
 use crate::services::assets::versions::error::AssetsError;
 use crate::services::assets::versions::store;
@@ -1091,10 +1089,10 @@ fn normalize_spread_penalty(p: SpreadPenalty) -> Option<SpreadPenalty> {
 // ===================================================== Cached fetch
 
 #[cached(
-    ty = "LruTtlCache<u32, Arc<Vec<NpcUnit>>>",
-    create = "{ LruTtlCache::builder().size(DEFAULT_CACHE_SIZE).ttl(DEFAULT_CACHE_TTL).build() }",
+    max_size = 64,
+    ttl = 86400,
     convert = "{ version }",
-    result = true,
+    key = "u32",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_npc_units(

--- a/api/src/services/assets/versions/ranks.rs
+++ b/api/src/services/assets/versions/ranks.rs
@@ -4,15 +4,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_graphql::{ComplexObject, SimpleObject};
-use cached::LruTtlCache;
 use cached::macros::cached;
 use object_store::aws::AmazonS3;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::services::assets::versions::common::{
-    DEFAULT_CACHE_SIZE, DEFAULT_CACHE_TTL, IMAGE_BASE_URL,
-};
+use crate::services::assets::versions::common::IMAGE_BASE_URL;
 use crate::services::assets::versions::error::AssetsError;
 use crate::services::assets::versions::localization;
 
@@ -168,10 +165,10 @@ pub(crate) fn build_ranks(loc: &HashMap<String, String>) -> Vec<Rank> {
 }
 
 #[cached(
-    ty = "LruTtlCache<(u32, String), Arc<Vec<Rank>>>",
-    create = "{ LruTtlCache::builder().size(DEFAULT_CACHE_SIZE).ttl(DEFAULT_CACHE_TTL).build() }",
+    max_size = 64,
+    ttl = 86400,
     convert = r#"{ (version, language.to_owned()) }"#,
-    result = true,
+    key = "(u32, String)",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_ranks(

--- a/api/src/services/assets/versions/steam_info.rs
+++ b/api/src/services/assets/versions/steam_info.rs
@@ -6,19 +6,16 @@
 //! preserved verbatim, including field order, so this endpoint can swap in
 //! transparently.
 
-use core::time::Duration;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use bytes::Bytes;
 use cached::macros::cached;
-use cached::{LruTtlCache, TtlCache};
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use object_store::aws::AmazonS3;
 use serde::Serialize;
 use utoipa::ToSchema;
 
-use crate::services::assets::versions::common::{DEFAULT_CACHE_SIZE, DEFAULT_CACHE_TTL};
 use crate::services::assets::versions::error::AssetsError;
 use crate::services::assets::versions::store;
 
@@ -95,10 +92,10 @@ pub(crate) fn build_steam_info(text: &str) -> Result<SteamInfo, AssetsError> {
 }
 
 #[cached(
-    ty = "LruTtlCache<u32, Arc<SteamInfo>>",
-    create = "{ LruTtlCache::builder().size(DEFAULT_CACHE_SIZE).ttl(DEFAULT_CACHE_TTL).build() }",
+    max_size = 64,
+    ttl = 86400,
     convert = "{ version }",
-    result = true,
+    key = "u32",
     sync_writes = "by_key"
 )]
 pub(crate) async fn fetch_steam_info(
@@ -112,20 +109,13 @@ pub(crate) async fn fetch_steam_info(
 /// Bucket key for the pre-built array of every version's steam info, produced
 /// by `scripts/update_r2_index.sh`.
 const ALL_STEAM_INFO_KEY: &str = "assets-api-res/steam-info/all.json.zst";
-const ALL_STEAM_INFO_TTL: Duration = Duration::from_mins(15);
 
 /// Fetch the pre-built `[SteamInfo]` array spanning every known version.
 ///
 /// The script collects and parses each version's `steam.inf` offline, so this
 /// is served as the raw JSON bytes it produced — already in the same shape and
 /// field order as [`SteamInfo`] — without re-fetching N files per request.
-#[cached(
-    ty = "TtlCache<u8, Bytes>",
-    create = "{ TtlCache::with_ttl(ALL_STEAM_INFO_TTL) }",
-    convert = "{ 0_u8 }",
-    result = true,
-    sync_writes = "by_key"
-)]
+#[cached(ttl = 900, convert = "{ 0_u8 }", key = "u8", sync_writes = "by_key")]
 pub(crate) async fn fetch_all_steam_info(r2: &AmazonS3) -> Result<Bytes, AssetsError> {
     Ok(store::fetch_zst(r2, ALL_STEAM_INFO_KEY).await?)
 }

--- a/api/src/services/assets/versions/store.rs
+++ b/api/src/services/assets/versions/store.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use async_compression::tokio::bufread::ZstdDecoder;
 use bytes::Bytes;
-use cached::TtlCache;
 use cached::macros::cached;
 use object_store::aws::AmazonS3;
 use object_store::{ObjectStore, ObjectStoreExt, path::Path as ObjectPath};
@@ -135,10 +134,9 @@ pub(crate) async fn fetch_decompressed(
 }
 
 #[cached(
-    ty = "TtlCache<(u32, String), Bytes>",
-    create = "{ TtlCache::with_ttl(Duration::from_secs(60 * 60)) }",
+    ttl = 3600,
     convert = r#"{ (version, rel_path.clone()) }"#,
-    result = true,
+    key = "(u32, String)",
     sync_writes = "by_key"
 )]
 async fn fetch_decompressed_cached(

--- a/api/src/services/patreon/extractor.rs
+++ b/api/src/services/patreon/extractor.rs
@@ -1,6 +1,5 @@
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
-use cached::TtlCache;
 use cached::macros::cached;
 use reqwest::StatusCode;
 use sqlx::{Pool, Postgres};
@@ -91,11 +90,11 @@ fn extract_token_from_auth_header(headers: &axum::http::HeaderMap) -> Option<Str
 /// Returns `None` if the API key is not found, is disabled, or has no patron linked.
 /// Results are cached for 10 minutes.
 #[cached(
-    ty = "TtlCache<Uuid, Option<Uuid>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(10 * 60)) }",
+    ttl = 600,
     convert = "{ api_key }",
     sync_writes = "by_key",
-    key = "Uuid"
+    key = "Uuid",
+    cache_none = true
 )]
 pub(crate) async fn get_patron_id_for_api_key(
     pg_client: &Pool<Postgres>,

--- a/api/src/services/patreon/mod.rs
+++ b/api/src/services/patreon/mod.rs
@@ -8,14 +8,11 @@ pub(crate) mod types;
 pub(crate) mod verification_job;
 pub(crate) mod webhook_types;
 
-use cached::TtlCache;
 use cached::macros::cached;
 use sqlx::{Pool, Postgres};
 
 #[cached(
-    ty = "TtlCache<i64, bool>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_hours(1)) }",
-    result = true,
+    ttl = 3600,
     convert = "{ steam_id3 }",
     sync_writes = "by_key",
     key = "i64"

--- a/api/src/services/rate_limiter/client.rs
+++ b/api/src/services/rate_limiter/client.rs
@@ -1,7 +1,6 @@
 use core::time::Duration;
 
 use axum::http::StatusCode;
-use cached::TtlCache;
 use cached::macros::cached;
 use chrono::{DateTime, Utc};
 use redis::RedisResult;
@@ -187,12 +186,10 @@ impl RateLimitClient {
 
 // Helper functions outside the impl block since cached macros cannot be used directly on methods
 #[cached(
-    ty = "TtlCache<Uuid, bool>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60 * 60)) }",
+    ttl = 3600,
     convert = "{ api_key }",
     sync_writes = "by_key",
-    key = "Uuid",
-    result = true
+    key = "Uuid"
 )]
 async fn is_api_key_valid(pg_client: &Pool<Postgres>, api_key: Uuid) -> Result<bool, sqlx::Error> {
     let row = sqlx::query!(
@@ -205,12 +202,10 @@ async fn is_api_key_valid(pg_client: &Pool<Postgres>, api_key: Uuid) -> Result<b
 }
 
 #[cached(
-    ty = "TtlCache<String, Vec<Quota>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(10 * 60)) }",
+    ttl = 600,
     convert = r#"{ format!("{api_key}-{path}") }"#,
     sync_writes = "by_key",
-    key = "String",
-    result = true
+    key = "String"
 )]
 async fn get_custom_quotas(
     pg_client: &Pool<Postgres>,

--- a/api/src/services/steam/client.rs
+++ b/api/src/services/steam/client.rs
@@ -3,7 +3,6 @@ use std::collections::HashSet;
 
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
-use cached::TtlCache;
 use cached::macros::cached;
 use metrics::counter;
 use prost::Message;
@@ -239,14 +238,8 @@ impl SteamClient {
     }
 }
 
-#[cached(
-    ty = "TtlCache<u8, Vec<Patch>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(30 * 60)) }",
-    result = true,
-    convert = "{ 0 }",
-    sync_writes = "default"
-)]
-async fn fetch_patch_notes(http_client: &reqwest::Client) -> APIResult<Vec<Patch>> {
+#[cached(ttl = 1800, convert = "{ 0 }", key = "u8", sync_writes = "default")]
+async fn fetch_patch_notes(http_client: &reqwest::Client) -> Result<Vec<Patch>, APIError> {
     let response = http_client.get(RSS_ENDPOINT).send().await.map_err(|e| {
         APIError::status_msg(
             reqwest::StatusCode::INTERNAL_SERVER_ERROR,
@@ -284,14 +277,10 @@ async fn fetch_rss_text(http_client: &reqwest::Client, url: &str) -> APIResult<S
     })
 }
 
-#[cached(
-    ty = "TtlCache<u8, Vec<FeedItem>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(30 * 60)) }",
-    result = true,
-    convert = "{ 0 }",
-    sync_writes = "default"
-)]
-async fn fetch_combined_patch_feed(http_client: &reqwest::Client) -> APIResult<Vec<FeedItem>> {
+#[cached(ttl = 1800, convert = "{ 0 }", key = "u8", sync_writes = "default")]
+async fn fetch_combined_patch_feed(
+    http_client: &reqwest::Client,
+) -> Result<Vec<FeedItem>, APIError> {
     let (forum_rss, steam_rss) = tokio::try_join!(
         fetch_rss_text(http_client, RSS_ENDPOINT),
         fetch_rss_text(http_client, STEAM_NEWS_ENDPOINT),
@@ -323,17 +312,11 @@ async fn fetch_combined_patch_feed(http_client: &reqwest::Client) -> APIResult<V
     Ok(items)
 }
 
-#[cached(
-    ty = "TtlCache<u8, Vec<SteamServer>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(30)) }",
-    result = true,
-    convert = "{ 0 }",
-    sync_writes = "default"
-)]
+#[cached(ttl = 30, convert = "{ 0 }", key = "u8", sync_writes = "default")]
 async fn fetch_steam_server_list(
     http_client: &reqwest::Client,
     steam_api_key: &str,
-) -> APIResult<Vec<SteamServer>> {
+) -> Result<Vec<SteamServer>, APIError> {
     let response: GetSteamServerListResponse = http_client
         .get(format!(
             "https://api.steampowered.com/IGameServersService/GetServerList/v1/?key={steam_api_key}&filter=\\appid\\1422450"
@@ -349,13 +332,7 @@ async fn fetch_steam_server_list(
     Ok(response.response.servers)
 }
 
-#[cached(
-    ty = "TtlCache<u8, HashSet<u32>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(24 * 60 * 60)) }",
-    result = true,
-    convert = "{ 0 }",
-    sync_writes = "default"
-)]
+#[cached(ttl = 86400, convert = "{ 0 }", key = "u8", sync_writes = "default")]
 pub(crate) async fn get_protected_users_cached(
     ph_client: &sqlx::Pool<sqlx::Postgres>,
 ) -> sqlx::Result<HashSet<u32>> {
@@ -380,14 +357,8 @@ struct SteamClientVersionResult {
     min_allowed_version: Option<u32>,
 }
 
-#[cached(
-    ty = "TtlCache<u8, u32>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(5 * 60)) }",
-    result = true,
-    convert = "{ 0 }",
-    sync_writes = "default"
-)]
-async fn get_current_client_version(http_client: &reqwest::Client) -> APIResult<u32> {
+#[cached(ttl = 300, convert = "{ 0 }", key = "u8", sync_writes = "default")]
+async fn get_current_client_version(http_client: &reqwest::Client) -> Result<u32, APIError> {
     // Try the official Steam API first
     if let Ok(version) = get_client_version_from_steam_api(http_client).await {
         return Ok(version);
@@ -449,9 +420,7 @@ async fn get_client_version_from_github(http_client: &reqwest::Client) -> APIRes
 }
 
 #[cached(
-    ty = "TtlCache<u32, String>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(24 * 60 * 60)) }",
-    result = true,
+    ttl = 86400,
     convert = "{ steam_id }",
     sync_writes = "by_key",
     key = "u32"

--- a/live-events/Cargo.lock
+++ b/live-events/Cargo.lock
@@ -151,9 +151,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
@@ -175,9 +175,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -199,9 +199,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "num-traits",
  "serde",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -566,22 +566,9 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -627,7 +614,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 [[package]]
 name = "haste"
 version = "0.0.0"
-source = "git+https://github.com/deadlock-api/haste.git?rev=b1d693dafc3f6290b4b1c0984cf98503a6643507#b1d693dafc3f6290b4b1c0984cf98503a6643507"
+source = "git+https://github.com/deadlock-api/haste.git?rev=4a91bbfd36a90bb4eb9b215a80fccd59250d5051#4a91bbfd36a90bb4eb9b215a80fccd59250d5051"
 dependencies = [
  "haste_broadcast",
  "haste_core",
@@ -636,7 +623,7 @@ dependencies = [
 [[package]]
 name = "haste_broadcast"
 version = "0.0.0"
-source = "git+https://github.com/deadlock-api/haste.git?rev=b1d693dafc3f6290b4b1c0984cf98503a6643507#b1d693dafc3f6290b4b1c0984cf98503a6643507"
+source = "git+https://github.com/deadlock-api/haste.git?rev=4a91bbfd36a90bb4eb9b215a80fccd59250d5051#4a91bbfd36a90bb4eb9b215a80fccd59250d5051"
 dependencies = [
  "anyhow",
  "bytes",
@@ -655,7 +642,7 @@ dependencies = [
 [[package]]
 name = "haste_core"
 version = "0.0.0"
-source = "git+https://github.com/deadlock-api/haste.git?rev=b1d693dafc3f6290b4b1c0984cf98503a6643507#b1d693dafc3f6290b4b1c0984cf98503a6643507"
+source = "git+https://github.com/deadlock-api/haste.git?rev=4a91bbfd36a90bb4eb9b215a80fccd59250d5051#4a91bbfd36a90bb4eb9b215a80fccd59250d5051"
 dependencies = [
  "anyhow",
  "dungers",
@@ -673,7 +660,7 @@ dependencies = [
 [[package]]
 name = "haste_vartype"
 version = "0.0.0"
-source = "git+https://github.com/deadlock-api/haste.git?rev=b1d693dafc3f6290b4b1c0984cf98503a6643507#b1d693dafc3f6290b4b1c0984cf98503a6643507"
+source = "git+https://github.com/deadlock-api/haste.git?rev=4a91bbfd36a90bb4eb9b215a80fccd59250d5051#4a91bbfd36a90bb4eb9b215a80fccd59250d5051"
 dependencies = [
  "dungers",
  "thiserror",
@@ -687,9 +674,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -732,9 +719,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -875,12 +862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,8 +890,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1004,13 +983,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1019,12 +997,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1046,9 +1018,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru-slab"
@@ -1073,9 +1045,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -1095,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1208,9 +1180,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1218,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
  "itertools",
@@ -1237,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1250,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -1375,12 +1347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1434,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -1536,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -1740,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -1774,9 +1740,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snap"
@@ -1786,9 +1752,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1892,7 +1858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2168,12 +2133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,7 +2165,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "valveprotos"
 version = "0.0.0"
-source = "git+https://github.com/deadlock-api/valveprotos-rs.git?rev=63a9001f9bd1bb9095cc5c503ec3db80085f6bae#63a9001f9bd1bb9095cc5c503ec3db80085f6bae"
+source = "git+https://github.com/deadlock-api/valveprotos-rs.git?rev=d4ce19ea77083bdc4db690bbd906659f80f34be4#d4ce19ea77083bdc4db690bbd906659f80f34be4"
 dependencies = [
  "heck",
  "prost",
@@ -2245,27 +2204,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2276,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2286,9 +2236,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2296,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2309,52 +2259,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2581,97 +2497,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -2681,9 +2509,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2704,18 +2532,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2745,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/live-events/Cargo.toml
+++ b/live-events/Cargo.toml
@@ -17,11 +17,11 @@ tower-layer = "0.3.3"
 tower-http = { version = "0.6.11", features = ["cors", "normalize-path", "trace", "limit"] }
 tracing = "0.1.44"
 futures = "0.3.32"
-valveprotos = { git = "https://github.com/deadlock-api/valveprotos-rs.git", rev = "63a9001f9bd1bb9095cc5c503ec3db80085f6bae", features = ["serde", "user-msgs", "game-msgs"] }
-prost = "0.14.3"
+valveprotos = { git = "https://github.com/deadlock-api/valveprotos-rs.git", rev = "d4ce19ea77083bdc4db690bbd906659f80f34be4", features = ["serde", "user-msgs", "game-msgs"] }
+prost = "0.14.4"
 tryhard = "0.5.2"
 strum = { version = "0.28.0", features = ["derive"] }
-haste = { git = "https://github.com/deadlock-api/haste.git", rev = "b1d693dafc3f6290b4b1c0984cf98503a6643507" }
+haste = { git = "https://github.com/deadlock-api/haste.git", rev = "4a91bbfd36a90bb4eb9b215a80fccd59250d5051" }
 async-stream = "0.3.6"
 thiserror = "2.0.18"
 serde-env = "0.3.0"

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "1.1.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4863037a22757575c62f4f52c71bc833c7989c696c35eda5c83a4f36599b2bbd"
+checksum = "dc0df7748fe2f601e376916ab19e7bfc2c74461b8abe3bce2ce20036ad8de38f"
 dependencies = [
  "ahash",
  "cached_proc_macro",
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "cached_proc_macro"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a89b3ceb2f9166826b0d21b670a8720dbaeb3397428d1c7603e0ffacdfd37"
+checksum = "66e734c52502e6cf54dce2ba07108906b04b8fe57f4f5e3ef7d58267b4abf060"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -391,9 +391,9 @@ checksum = "26cf465651fa6ad902a2d327ba60c3a6bc61c6a2f4ad70d091cf20dfda0074ef"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -861,7 +861,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1346,7 +1346,7 @@ dependencies = [
 [[package]]
 name = "haste"
 version = "0.0.0"
-source = "git+https://github.com/deadlock-api/haste.git?rev=b1d693dafc3f6290b4b1c0984cf98503a6643507#b1d693dafc3f6290b4b1c0984cf98503a6643507"
+source = "git+https://github.com/deadlock-api/haste.git?rev=4a91bbfd36a90bb4eb9b215a80fccd59250d5051#4a91bbfd36a90bb4eb9b215a80fccd59250d5051"
 dependencies = [
  "haste_broadcast",
  "haste_core",
@@ -1355,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "haste_broadcast"
 version = "0.0.0"
-source = "git+https://github.com/deadlock-api/haste.git?rev=b1d693dafc3f6290b4b1c0984cf98503a6643507#b1d693dafc3f6290b4b1c0984cf98503a6643507"
+source = "git+https://github.com/deadlock-api/haste.git?rev=4a91bbfd36a90bb4eb9b215a80fccd59250d5051#4a91bbfd36a90bb4eb9b215a80fccd59250d5051"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "haste_core"
 version = "0.0.0"
-source = "git+https://github.com/deadlock-api/haste.git?rev=b1d693dafc3f6290b4b1c0984cf98503a6643507#b1d693dafc3f6290b4b1c0984cf98503a6643507"
+source = "git+https://github.com/deadlock-api/haste.git?rev=4a91bbfd36a90bb4eb9b215a80fccd59250d5051#4a91bbfd36a90bb4eb9b215a80fccd59250d5051"
 dependencies = [
  "anyhow",
  "dungers",
@@ -1392,7 +1392,7 @@ dependencies = [
 [[package]]
 name = "haste_vartype"
 version = "0.0.0"
-source = "git+https://github.com/deadlock-api/haste.git?rev=b1d693dafc3f6290b4b1c0984cf98503a6643507#b1d693dafc3f6290b4b1c0984cf98503a6643507"
+source = "git+https://github.com/deadlock-api/haste.git?rev=4a91bbfd36a90bb4eb9b215a80fccd59250d5051#4a91bbfd36a90bb4eb9b215a80fccd59250d5051"
 dependencies = [
  "dungers",
  "thiserror",
@@ -1487,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1932,13 +1932,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2096,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "metrics"
@@ -2857,9 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2880,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3341,9 +3340,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -4149,7 +4148,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "valveprotos"
 version = "0.0.0"
-source = "git+https://github.com/deadlock-api/valveprotos-rs.git?rev=63a9001f9bd1bb9095cc5c503ec3db80085f6bae#63a9001f9bd1bb9095cc5c503ec3db80085f6bae"
+source = "git+https://github.com/deadlock-api/valveprotos-rs.git?rev=d4ce19ea77083bdc4db690bbd906659f80f34be4#d4ce19ea77083bdc4db690bbd906659f80f34be4"
 dependencies = [
  "heck",
  "prost",
@@ -4200,9 +4199,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -4218,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4231,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4241,9 +4240,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4251,9 +4250,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4264,9 +4263,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -4333,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4748,18 +4747,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4789,9 +4788,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 anyhow = "1.0.102"
 async-compression = "0.4.42"
 base64 = "0.22.1"
-cached = "1.1"
+cached = "2.0"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 clickhouse = "0.15.1"
 common = { version = "0.1.0", path = "common" }
@@ -20,7 +20,7 @@ opentelemetry = { version = "0.32", features = ["logs", "trace"] }
 opentelemetry_sdk = { version = "0.32", features = ["logs", "trace"] }
 opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "logs", "trace"] }
 opentelemetry-appender-tracing = { version = "0.32", features = ["experimental_metadata_attributes"] }
-prost = "0.14.3"
+prost = "0.14.4"
 rand = "0.10.1"
 reqwest = "0.13.4"
 serde = { version = "1.0.228", features = ["derive"] }
@@ -33,5 +33,5 @@ tokio-util = "0.7.18"
 tracing = "0.1.44"
 tracing-opentelemetry = "0.33"
 tryhard = "0.5.2"
-valveprotos = { git = "https://github.com/deadlock-api/valveprotos-rs.git", rev = "63a9001f9bd1bb9095cc5c503ec3db80085f6bae" }
-haste = { git = "https://github.com/deadlock-api/haste.git", rev = "b1d693dafc3f6290b4b1c0984cf98503a6643507" }
+valveprotos = { git = "https://github.com/deadlock-api/valveprotos-rs.git", rev = "d4ce19ea77083bdc4db690bbd906659f80f34be4" }
+haste = { git = "https://github.com/deadlock-api/haste.git", rev = "4a91bbfd36a90bb4eb9b215a80fccd59250d5051" }

--- a/tools/hltv-scraper/src/active_matches.rs
+++ b/tools/hltv-scraper/src/active_matches.rs
@@ -1,4 +1,3 @@
-use cached::TtlCache;
 use cached::macros::cached;
 use serde::{Deserialize, Serialize};
 use tracing::info;
@@ -57,13 +56,7 @@ fn has_objective(mask: u32, objective: ECitadelTeamObjective) -> bool {
     mask & (1 << (objective as u32)) != 0
 }
 
-#[cached(
-    ty = "TtlCache<u8, Vec<ActiveMatch>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(60)) }",
-    result = true,
-    convert = "{ 0 }",
-    sync_writes = "default"
-)]
+#[cached(ttl = 60, convert = "{ 0 }", key = "u8", sync_writes = "default")]
 pub(crate) async fn fetch_active_matches_cached() -> anyhow::Result<Vec<ActiveMatch>> {
     let client = reqwest::Client::new();
     let res = client

--- a/tools/matchdata-downloader/src/main.rs
+++ b/tools/matchdata-downloader/src/main.rs
@@ -15,7 +15,6 @@ use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use anyhow::Context;
-use cached::LruCache;
 use cached::macros::cached;
 use clickhouse::Client;
 use futures::StreamExt;
@@ -388,9 +387,9 @@ async fn delete_object<S: ObjectStore + ?Sized>(store: &S, key: &Path) -> object
 }
 
 #[cached(
-    ty = "LruCache<String, bool>",
-    create = "{ LruCache::with_size(10_000) }",
-    convert = r#"{ format!("{file_path}") }"#
+    max_size = 10_000,
+    convert = r#"{ format!("{file_path}") }"#,
+    key = "String"
 )]
 #[instrument(skip(store))]
 async fn key_exists<S: ObjectStore + ?Sized>(store: &S, file_path: &Path) -> bool {

--- a/tools/steam-profile-fetcher/src/main.rs
+++ b/tools/steam-profile-fetcher/src/main.rs
@@ -17,7 +17,6 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use cached::macros::cached;
-use cached::TtlCache;
 use futures::stream::StreamExt;
 use itertools::Itertools;
 use metrics::{counter, gauge};
@@ -279,13 +278,7 @@ async fn delete_profiles(
         .await
 }
 
-#[cached(
-    ty = "TtlCache<u8, Vec<u32>>",
-    create = "{ TtlCache::with_ttl(std::time::Duration::from_secs(24 * 60 * 60)) }",
-    result = true,
-    convert = "{ 0 }",
-    sync_writes = "default"
-)]
+#[cached(ttl = 86400, convert = "{ 0 }", key = "u8", sync_writes = "default")]
 async fn get_protected_users_cached(
     ph_client: &sqlx::Pool<sqlx::Postgres>,
 ) -> sqlx::Result<Vec<u32>> {

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -82,7 +82,7 @@ importers:
         version: 1.11.21
       deadlock_api_client:
         specifier: github:deadlock-api/openapi-clients#path:/typescript
-        version: https://codeload.github.com/deadlock-api/openapi-clients/tar.gz/19424d801c9be52a389cb7b1b48bd2e7982dc56c#path:/typescript
+        version: https://codeload.github.com/deadlock-api/openapi-clients/tar.gz/03c4a76f491fee0588c6ac67a35b6a21d2c855f1#path:/typescript
       framer-motion:
         specifier: ^12.40.0
         version: 12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2611,8 +2611,8 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -2894,8 +2894,8 @@ packages:
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
-  deadlock_api_client@https://codeload.github.com/deadlock-api/openapi-clients/tar.gz/19424d801c9be52a389cb7b1b48bd2e7982dc56c#path:/typescript:
-    resolution: {gitHosted: true, path: /typescript, tarball: https://codeload.github.com/deadlock-api/openapi-clients/tar.gz/19424d801c9be52a389cb7b1b48bd2e7982dc56c}
+  deadlock_api_client@https://codeload.github.com/deadlock-api/openapi-clients/tar.gz/03c4a76f491fee0588c6ac67a35b6a21d2c855f1#path:/typescript:
+    resolution: {path: /typescript, tarball: https://codeload.github.com/deadlock-api/openapi-clients/tar.gz/03c4a76f491fee0588c6ac67a35b6a21d2c855f1}
     version: 0.1.0
 
   debug@4.4.3:
@@ -6646,11 +6646,11 @@ snapshots:
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
 
-  acorn-jsx@5.3.2(acorn@8.16.0):
+  acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
-  acorn@8.16.0: {}
+  acorn@8.17.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -6933,7 +6933,7 @@ snapshots:
 
   dayjs@1.11.21: {}
 
-  deadlock_api_client@https://codeload.github.com/deadlock-api/openapi-clients/tar.gz/19424d801c9be52a389cb7b1b48bd2e7982dc56c#path:/typescript:
+  deadlock_api_client@https://codeload.github.com/deadlock-api/openapi-clients/tar.gz/03c4a76f491fee0588c6ac67a35b6a21d2c855f1#path:/typescript:
     dependencies:
       axios: 1.17.0
     transitivePeerDependencies:
@@ -7149,8 +7149,8 @@ snapshots:
 
   espree@11.2.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 5.0.1
 
   esquery@1.7.0:
@@ -8440,7 +8440,7 @@ snapshots:
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
     optional: true


### PR DESCRIPTION
## Summary

Updates all dependencies across the four crates (`api/`, `website/`, `live-events/`, `tools/`), refreshes the pinned git dependencies, and migrates the `cached` crate from 1.1 → 2.0 (the one breaking upgrade).

## Dependency changes

| Crate | Notable bumps | git deps |
|---|---|---|
| `api/` | **cached 1.1→2.0**, uuid, prost, regex, + transitives | valveprotos → `d4ce19ea`, clickhouse-antlr4 |
| `tools/` | **cached 1.1→2.0**, prost, + transitives | valveprotos → `d4ce19ea`, haste → `4a91bbfd` |
| `live-events/` | prost, + transitives | valveprotos → `d4ce19ea`, haste → `4a91bbfd` |
| `website/` | all already at latest | deadlock_api_client → `03c4a76f` |

`metrics` stays pinned at `=0.24.3` (0.24.4+ break counter aggregation). `dungers` was already at its latest commit.

## `cached` 2.0 migration (breaking)

Affected `api/` (~57 `#[cached]` blocks) and 3 `tools/` members:

- Removed the deleted `result = true` attribute — `Result` returns now cache only `Ok` by default (same behavior).
- Replaced removed constructors (`TtlCache::with_ttl`, `LruCache::with_size`, `.size()`) with the macro's native `ttl` / `max_size` attributes. This deliberately keeps the generated `.build().unwrap_or_else(panic)` inside library code, so **no `unwrap`/`expect` is introduced in our source**.
- Added `key` where `convert` blocks previously relied on `ty` for the key type; added `cache_none = true` to the one `Option`-valued cache to preserve 1.x None-caching.
- Changed cached functions returning type aliases (`APIResult<T>`, `SteamProxyResult<T>`) to the literal `Result<T, E>` — the 2.0 macro only auto-detects a `Result` return when the type's last path segment is literally `Result`.
- Inlined the former shared `DEFAULT_CACHE_*` constants as literals (macro attributes require integer literals, not const paths).

## Verification

All four crates: `cargo build` / `cargo clippy` clean, `cargo fmt`, `cargo machete` (no unused deps). Website: `tsc --noEmit`, `oxlint`, and `vite build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)