### PR TITLE
feat(assets): add dash stats to hero starting stats; fix damage amp icon 404

### DIFF
--- a/api/src/services/assets/versions/heroes.rs
+++ b/api/src/services/assets/versions/heroes.rs
@@ -66,14 +66,14 @@ struct RawStartingStats {
     e_tech_range: f64,
     #[serde(default, rename = "EBulletArmorDamageReduction")]
     e_bullet_armor_damage_reduction: Option<f64>,
-    #[serde(rename = "EGroundDashDistanceInMeters")]
-    e_ground_dash_distance_in_meters: f64,
-    #[serde(rename = "EGroundDashDuration")]
-    e_ground_dash_duration: f64,
-    #[serde(rename = "EAirDashDistanceInMeters")]
-    e_air_dash_distance_in_meters: f64,
-    #[serde(rename = "EAirDashDuration")]
-    e_air_dash_duration: f64,
+    #[serde(default, rename = "EGroundDashDistanceInMeters")]
+    e_ground_dash_distance_in_meters: Option<f64>,
+    #[serde(default, rename = "EGroundDashDuration")]
+    e_ground_dash_duration: Option<f64>,
+    #[serde(default, rename = "EAirDashDistanceInMeters")]
+    e_air_dash_distance_in_meters: Option<f64>,
+    #[serde(default, rename = "EAirDashDuration")]
+    e_air_dash_duration: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -564,10 +564,14 @@ pub(crate) struct StartingStats {
     pub tech_range: StartingStat,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bullet_armor_damage_reduction: Option<StartingStat>,
-    pub ground_dash_distance_in_meters: StartingStat,
-    pub ground_dash_duration: StartingStat,
-    pub air_dash_distance_in_meters: StartingStat,
-    pub air_dash_duration: StartingStat,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ground_dash_distance_in_meters: Option<StartingStat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ground_dash_duration: Option<StartingStat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub air_dash_distance_in_meters: Option<StartingStat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub air_dash_duration: Option<StartingStat>,
 }
 
 #[derive(Debug, Serialize, Clone, ToSchema)]
@@ -931,18 +935,18 @@ fn build_starting_stats(s: &RawStartingStats) -> StartingStats {
         bullet_armor_damage_reduction: s
             .e_bullet_armor_damage_reduction
             .map(|v| mk!(v, "EBulletArmorDamageReduction", float)),
-        ground_dash_distance_in_meters: mk!(
-            s.e_ground_dash_distance_in_meters,
-            "EGroundDashDistanceInMeters",
-            float
-        ),
-        ground_dash_duration: mk!(s.e_ground_dash_duration, "EGroundDashDuration", float),
-        air_dash_distance_in_meters: mk!(
-            s.e_air_dash_distance_in_meters,
-            "EAirDashDistanceInMeters",
-            float
-        ),
-        air_dash_duration: mk!(s.e_air_dash_duration, "EAirDashDuration", float),
+        ground_dash_distance_in_meters: s
+            .e_ground_dash_distance_in_meters
+            .map(|v| mk!(v, "EGroundDashDistanceInMeters", float)),
+        ground_dash_duration: s
+            .e_ground_dash_duration
+            .map(|v| mk!(v, "EGroundDashDuration", float)),
+        air_dash_distance_in_meters: s
+            .e_air_dash_distance_in_meters
+            .map(|v| mk!(v, "EAirDashDistanceInMeters", float)),
+        air_dash_duration: s
+            .e_air_dash_duration
+            .map(|v| mk!(v, "EAirDashDuration", float)),
     }
 }
 

--- a/api/src/services/assets/versions/heroes.rs
+++ b/api/src/services/assets/versions/heroes.rs
@@ -66,6 +66,14 @@ struct RawStartingStats {
     e_tech_range: f64,
     #[serde(default, rename = "EBulletArmorDamageReduction")]
     e_bullet_armor_damage_reduction: Option<f64>,
+    #[serde(rename = "EGroundDashDistanceInMeters")]
+    e_ground_dash_distance_in_meters: f64,
+    #[serde(rename = "EGroundDashDuration")]
+    e_ground_dash_duration: f64,
+    #[serde(rename = "EAirDashDistanceInMeters")]
+    e_air_dash_distance_in_meters: f64,
+    #[serde(rename = "EAirDashDuration")]
+    e_air_dash_duration: f64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -556,6 +564,10 @@ pub(crate) struct StartingStats {
     pub tech_range: StartingStat,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bullet_armor_damage_reduction: Option<StartingStat>,
+    pub ground_dash_distance_in_meters: StartingStat,
+    pub ground_dash_duration: StartingStat,
+    pub air_dash_distance_in_meters: StartingStat,
+    pub air_dash_duration: StartingStat,
 }
 
 #[derive(Debug, Serialize, Clone, ToSchema)]
@@ -919,6 +931,18 @@ fn build_starting_stats(s: &RawStartingStats) -> StartingStats {
         bullet_armor_damage_reduction: s
             .e_bullet_armor_damage_reduction
             .map(|v| mk!(v, "EBulletArmorDamageReduction", float)),
+        ground_dash_distance_in_meters: mk!(
+            s.e_ground_dash_distance_in_meters,
+            "EGroundDashDistanceInMeters",
+            float
+        ),
+        ground_dash_duration: mk!(s.e_ground_dash_duration, "EGroundDashDuration", float),
+        air_dash_distance_in_meters: mk!(
+            s.e_air_dash_distance_in_meters,
+            "EAirDashDistanceInMeters",
+            float
+        ),
+        air_dash_duration: mk!(s.e_air_dash_duration, "EAirDashDuration", float),
     }
 }
 

--- a/api/src/services/assets/versions/items/template.rs
+++ b/api/src/services/assets/versions/items/template.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 
 use crate::services::assets::versions::items::css_lookup::CssIndex;
 use crate::services::assets::versions::items::paths::{
-    parse_img_path, pascal_case_to_snake_case, prettify_pascal_case,
+    SVGS_BASE_URL, parse_img_path, pascal_case_to_snake_case, prettify_pascal_case,
 };
 use indexmap::IndexMap;
 
@@ -261,11 +261,21 @@ async fn resolve_inline_attribute(ctx: &TemplateCtx<'_>, css_class: &str) -> Str
     let (bg_raw, wash) = ctx
         .base_styles_css
         .find_base_styles(&format!(".InlineAttributeIcon.{css_class}"));
-    let bg = parse_img_path(bg_raw.as_deref());
+
+    // The game CSS maps DamageAmp to `images/damage.psd`, which doesn't exist
+    // in the assets bucket. Point it at the crit-damage property icon instead.
+    let (bg, svg_name_override): (Option<String>, Option<&str>) = match css_class {
+        "DamageAmp" => {
+            let name = "icons/properties/damage_crit_color.svg";
+            (Some(format!("{SVGS_BASE_URL}/{name}")), Some(name))
+        }
+        _ => (parse_img_path(bg_raw.as_deref()), None),
+    };
 
     let img_tag = match bg.as_deref() {
         Some(bg_url) if bg_url.ends_with(".svg") => {
-            let svg_name = bg_url.rsplit('/').next().unwrap_or(bg_url);
+            let svg_name =
+                svg_name_override.unwrap_or_else(|| bg_url.rsplit('/').next().unwrap_or(bg_url));
             if let Some(svg) = fetch_svg(svg_name).await.as_ref().clone() {
                 add_fill_to_svg(&svg, wash.as_deref())
             } else if wash.is_some() {

--- a/api/src/services/assets/versions/items/template.rs
+++ b/api/src/services/assets/versions/items/template.rs
@@ -262,8 +262,11 @@ async fn resolve_inline_attribute(ctx: &TemplateCtx<'_>, css_class: &str) -> Str
         .base_styles_css
         .find_base_styles(&format!(".InlineAttributeIcon.{css_class}"));
 
-    // The game CSS maps DamageAmp to `images/damage.psd`, which doesn't exist
-    // in the assets bucket. Point it at the crit-damage property icon instead.
+    // The game CSS maps DamageAmp to a bare `images/damage_psd.vtex`. That path
+    // hits the `parse_img_path` quirk that skips the `.psd`->`.png` rewrite, so
+    // it resolves to `images/damage.psd` (never uploaded) instead of the real
+    // `images/damage.png`. Use the themeable crit-damage property SVG instead,
+    // matching how the other inline-attribute icons render with a wash color.
     let (bg, svg_name_override): (Option<String>, Option<&str>) = match css_class {
         "DamageAmp" => {
             let name = "icons/properties/damage_crit_color.svg";

--- a/api/tests/heroes_snapshots/heroes_english_v6514.snap
+++ b/api/tests/heroes_snapshots/heroes_english_v6514.snap
@@ -1458,6 +1458,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -1469,6 +1477,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -3023,6 +3039,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -3034,6 +3058,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -4593,6 +4625,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -4604,6 +4644,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -6158,6 +6206,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -6169,6 +6225,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -7723,6 +7787,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.5
@@ -7734,6 +7806,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -9293,6 +9373,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -9304,6 +9392,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -10858,6 +10954,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -10869,6 +10973,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -12423,6 +12535,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -12434,6 +12554,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -13989,6 +14117,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.75
@@ -14000,6 +14136,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -15555,6 +15699,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -15566,6 +15718,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -17125,6 +17285,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -17136,6 +17304,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -18690,6 +18866,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -18701,6 +18885,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -20255,6 +20447,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.5
@@ -20266,6 +20466,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -21820,6 +22028,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -21831,6 +22047,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -23395,6 +23619,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.5
@@ -23406,6 +23638,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -24961,6 +25201,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -24972,6 +25220,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -26527,6 +26783,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -26538,6 +26802,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -28092,6 +28364,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -28103,6 +28383,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -29636,6 +29924,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -29647,6 +29943,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -31206,6 +31510,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -31217,6 +31529,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -32777,6 +33097,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -32788,6 +33116,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -34342,6 +34678,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -34353,6 +34697,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -35912,6 +36264,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -35923,6 +36283,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -37450,6 +37818,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -37461,6 +37837,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -38984,6 +39368,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -38995,6 +39387,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -40518,6 +40918,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -40529,6 +40937,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -42066,6 +42482,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -42077,6 +42501,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -43600,6 +44032,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -43611,6 +44051,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -45161,6 +45609,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -45172,6 +45628,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -46703,6 +47167,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -46714,6 +47186,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -48264,6 +48744,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.5
@@ -48275,6 +48763,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -49813,6 +50309,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -49824,6 +50328,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -51347,6 +51859,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -51358,6 +51878,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -52874,6 +53402,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -52885,6 +53421,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -54401,6 +54945,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -54412,6 +54964,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -55967,6 +56527,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -55978,6 +56546,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -57512,6 +58088,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -57523,6 +58107,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -59079,6 +59671,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -59090,6 +59690,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -60628,6 +61236,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -60639,6 +61255,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -62175,6 +62799,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -62186,6 +62818,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -63734,6 +64374,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -63745,6 +64393,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -65297,6 +65953,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 3.5
@@ -65308,6 +65972,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -66869,6 +67541,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -66880,6 +67560,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -68437,6 +69125,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.5
@@ -68448,6 +69144,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -70009,6 +70713,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -70020,6 +70732,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -71554,6 +72274,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -71565,6 +72293,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -73113,6 +73849,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -73124,6 +73868,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -74659,6 +75411,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -74670,6 +75430,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -76204,6 +76972,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -76215,6 +76991,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -77762,6 +78546,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.5
@@ -77773,6 +78565,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -79303,6 +80103,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -79314,6 +80122,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -80845,6 +81661,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -80856,6 +81680,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -82396,6 +83228,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -82407,6 +83247,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -83959,6 +84807,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -83970,6 +84826,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -85522,6 +86386,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -85533,6 +86405,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -87068,6 +87948,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -87079,6 +87967,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -88625,6 +89521,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -88636,6 +89540,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -90188,6 +91100,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.5
@@ -90199,6 +91119,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -91752,6 +92680,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -91763,6 +92699,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -93283,6 +94227,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -93294,6 +94246,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -94832,6 +95792,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -94843,6 +95811,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",

--- a/api/tests/heroes_snapshots/heroes_german_v6514.snap
+++ b/api/tests/heroes_snapshots/heroes_german_v6514.snap
@@ -1458,6 +1458,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -1469,6 +1477,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -3023,6 +3039,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -3034,6 +3058,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -4593,6 +4625,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -4604,6 +4644,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -6158,6 +6206,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -6169,6 +6225,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -7723,6 +7787,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.5
@@ -7734,6 +7806,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -9293,6 +9373,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -9304,6 +9392,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -10858,6 +10954,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -10869,6 +10973,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -12423,6 +12535,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -12434,6 +12554,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -13989,6 +14117,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.75
@@ -14000,6 +14136,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -15555,6 +15699,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -15566,6 +15718,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -17125,6 +17285,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -17136,6 +17304,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -18690,6 +18866,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -18701,6 +18885,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -20255,6 +20447,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.5
@@ -20266,6 +20466,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -21820,6 +22028,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -21831,6 +22047,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -23395,6 +23619,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.5
@@ -23406,6 +23638,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -24961,6 +25201,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -24972,6 +25220,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -26527,6 +26783,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -26538,6 +26802,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -28092,6 +28364,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -28103,6 +28383,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -29636,6 +29924,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -29647,6 +29943,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -31206,6 +31510,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -31217,6 +31529,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -32777,6 +33097,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -32788,6 +33116,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -34342,6 +34678,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -34353,6 +34697,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -35912,6 +36264,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -35923,6 +36283,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -37450,6 +37818,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -37461,6 +37837,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -38984,6 +39368,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -38995,6 +39387,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -40518,6 +40918,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -40529,6 +40937,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -42066,6 +42482,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -42077,6 +42501,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -43600,6 +44032,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -43611,6 +44051,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -45161,6 +45609,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -45172,6 +45628,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -46703,6 +47167,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -46714,6 +47186,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -48264,6 +48744,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.5
@@ -48275,6 +48763,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -49813,6 +50309,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -49824,6 +50328,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -51347,6 +51859,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -51358,6 +51878,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -52874,6 +53402,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -52885,6 +53421,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -54401,6 +54945,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -54412,6 +54964,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -55967,6 +56527,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -55978,6 +56546,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -57512,6 +58088,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -57523,6 +58107,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -59079,6 +59671,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -59090,6 +59690,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -60628,6 +61236,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -60639,6 +61255,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -62175,6 +62799,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -62186,6 +62818,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -63734,6 +64374,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -63745,6 +64393,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -65297,6 +65953,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 3.5
@@ -65308,6 +65972,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -66869,6 +67541,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -66880,6 +67560,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -68437,6 +69125,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.5
@@ -68448,6 +69144,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -70009,6 +70713,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -70020,6 +70732,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.7
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -71554,6 +72274,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -71565,6 +72293,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -73113,6 +73849,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -73124,6 +73868,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -74659,6 +75411,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -74670,6 +75430,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -76204,6 +76972,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -76215,6 +76991,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -77762,6 +78546,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.5
@@ -77773,6 +78565,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -79303,6 +80103,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -79314,6 +80122,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -80845,6 +81661,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -80856,6 +81680,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -82396,6 +83228,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -82407,6 +83247,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -83959,6 +84807,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -83970,6 +84826,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -85522,6 +86386,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -85533,6 +86405,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -87068,6 +87948,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -87079,6 +87967,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -88625,6 +89521,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.49
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -88636,6 +89540,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -90188,6 +91100,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.5
@@ -90199,6 +91119,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -91752,6 +92680,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 1.0
@@ -91763,6 +92699,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -93283,6 +94227,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.47
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -93294,6 +94246,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.68
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",
@@ -94832,6 +95792,14 @@ expression: heroes
         "display_stat_name": "EAbilityResourceRegenPerSecond",
         "value": 0
       },
+      "air_dash_distance_in_meters": {
+        "display_stat_name": "EAirDashDistanceInMeters",
+        "value": 8.0
+      },
+      "air_dash_duration": {
+        "display_stat_name": "EAirDashDuration",
+        "value": 0.43
+      },
       "base_health_regen": {
         "display_stat_name": "EBaseHealthRegen",
         "value": 2.0
@@ -94843,6 +95811,14 @@ expression: heroes
       "crouch_speed": {
         "display_stat_name": "ECrouchSpeed",
         "value": 4.75
+      },
+      "ground_dash_distance_in_meters": {
+        "display_stat_name": "EGroundDashDistanceInMeters",
+        "value": 10.0
+      },
+      "ground_dash_duration": {
+        "display_stat_name": "EGroundDashDuration",
+        "value": 0.62
       },
       "heavy_melee_damage": {
         "display_stat_name": "EHeavyMeleeDamage",


### PR DESCRIPTION
## Summary

Two asset-API changes for the hero data and item description rendering.

### 1. Dash stats in hero starting stats
Added four dash-related fields to the hero starting stats (`api/src/services/assets/versions/heroes.rs`) — wired through the raw deserialization struct, the `StartingStats` output struct, and `build_starting_stats`:

- `EGroundDashDistanceInMeters` → `ground_dash_distance_in_meters`
- `EGroundDashDuration` → `ground_dash_duration`
- `EAirDashDistanceInMeters` → `air_dash_distance_in_meters`
- `EAirDashDuration` → `air_dash_duration`

Validated against live R2 (version 6597): all 64 heroes parse cleanly; e.g. `hero_base` returns `ground_dist=10.0, ground_dur=0.68, air_dist=8.0, air_dur=0.47`.

### 2. Damage amp icon 404
The game CSS maps `.InlineAttributeIcon.DamageAmp` to `images/damage_psd.vtex`, which resolved to the non-existent `.../assets-api-res/images/damage.psd`. Remapped it to the crit-damage property icon that exists in the bucket:

```
https://assets-bucket.deadlock-api.com/assets-api-res/icons/icons/properties/damage_crit_color.svg
```

The override flows through the existing SVG path, so the icon is fetched and inlined with its `wash-color` fill like the other property icons.

> Note: other inline-attribute property icons (e.g. `SpiritDamage`) are flattened to `.../icons/<name>.svg` rather than the nested `.../icons/icons/properties/<name>.svg`. Only `DamageAmp` was reported as 404ing, so the fix is scoped to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)