### PR TITLE
feat(demo): track job duration and log query text

### DIFF
--- a/api/src/routes/v1/matches/demo/job.rs
+++ b/api/src/routes/v1/matches/demo/job.rs
@@ -31,6 +31,8 @@ pub(crate) struct JobRecord {
     pub(crate) enqueued_at: i64,
     /// Unix seconds the worker started processing, once it has.
     pub(crate) running_since: Option<i64>,
+    /// Unix seconds the job finished (done or failed), once it has.
+    pub(crate) completed_at: Option<i64>,
     pub(crate) result_url: Option<String>,
     pub(crate) error: Option<String>,
 }

--- a/api/src/routes/v1/matches/demo/submit.rs
+++ b/api/src/routes/v1/matches/demo/submit.rs
@@ -51,7 +51,7 @@ pub(super) struct DemoQueryJobResponse {
     summary = "Demo Query",
     description = "
 Submit a SQL query against a match's demo file. The work (download + decompress + parse +
-query) takes ~12s, so this is asynchronous: the endpoint returns a `job_id` you poll via
+query) takes ~55s, so this is asynchronous: the endpoint returns a `job_id` you poll via
 `/demo/query/{job_id}`. Once done, the status response carries a public URL to the result
 artifact (Parquet or NDJSON).
 
@@ -137,6 +137,7 @@ pub(super) async fn submit(
         queue_ticket: slot.ticket,
         enqueued_at,
         running_since: None,
+        completed_at: None,
         result_url: None,
         error: None,
     };

--- a/api/src/routes/v1/matches/demo/worker.rs
+++ b/api/src/routes/v1/matches/demo/worker.rs
@@ -13,7 +13,7 @@ use object_store::aws::AmazonS3;
 use object_store::path::Path;
 use redis::aio::MultiplexedConnection;
 use tokio::sync::{Semaphore, mpsc};
-use tracing::error;
+use tracing::{error, info};
 
 use super::job::{JobRecord, JobStatus, store as store_job};
 use super::{OutputFormat, download, format};
@@ -25,7 +25,7 @@ const MAX_QUEUE_DEPTH: usize = 32;
 /// memory, so keep this tiny. Bump only after measuring headroom.
 pub(super) const MAX_CONCURRENT: usize = 4;
 /// Rough per-job duration used purely for the status endpoint's wait estimate.
-pub(super) const AVG_JOB_SECONDS: u64 = 20;
+pub(super) const AVG_JOB_SECONDS: u64 = 55;
 
 pub(crate) struct QueryJob {
     pub(crate) job_id: String,
@@ -110,13 +110,23 @@ impl QuerySlot {
 }
 
 async fn run_job(mut redis: MultiplexedConnection, r2: &AmazonS3, public_url: &str, job: QueryJob) {
+    info!(
+        job_id = %job.job_id,
+        match_id = job.match_id,
+        format = job.format.extension(),
+        query = %job.sql,
+        "Running demo query job"
+    );
+
+    let running_since = chrono::Utc::now().timestamp();
     let mut record = JobRecord {
         status: JobStatus::Running,
         match_id: job.match_id,
         format: job.format,
         queue_ticket: job.queue_ticket,
         enqueued_at: job.enqueued_at,
-        running_since: Some(chrono::Utc::now().timestamp()),
+        running_since: Some(running_since),
+        completed_at: None,
         result_url: None,
         error: None,
     };
@@ -135,6 +145,16 @@ async fn run_job(mut redis: MultiplexedConnection, r2: &AmazonS3, public_url: &s
             record.error = Some(e.to_string());
         }
     }
+
+    let completed_at = chrono::Utc::now().timestamp();
+    record.completed_at = Some(completed_at);
+    info!(
+        job_id = %job.job_id,
+        match_id = job.match_id,
+        status = ?record.status,
+        duration_secs = completed_at.saturating_sub(running_since),
+        "Finished demo query job"
+    );
 
     if let Err(e) = store_job(&mut redis, &job.job_id, &record).await {
         error!("Failed to store demo query job {} result: {e}", job.job_id);


### PR DESCRIPTION
## Why

The demo query endpoints had no observability into how they perform or what people run:

- `JobRecord` stored `running_since` but **no completion timestamp**, so processing duration was not derivable from stored data (it had to be reconstructed from R2 object `LastModified`).
- The **SQL query text was never persisted or logged** — only hashed into the `job_id` — so there was no way to see what queries users submit.
- The wait estimate was based on `AVG_JOB_SECONDS = 20` and the docs claimed "~12s", but measured successful runs took **~46–66s**.

## What

- **`job.rs`**: add `completed_at: Option<i64>` to `JobRecord`, set when a job finishes (done or failed). Duration is now `completed_at - running_since`.
- **`worker.rs`**: `info!` the **full query text** + metadata at job start, and `status` + `duration_secs` at job end.
- **`worker.rs` / `submit.rs`**: correct the estimate — `AVG_JOB_SECONDS` `20 → 55`, doc string `~12s → ~55s`.

## Notes

- `completed_at` only populates on jobs run after deploy (Redis records have a 24h TTL).
- The query logs are the durable record of query types; they accumulate in the log pipeline from the next deploy onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)