### PR TITLE
feat(api): add POST live demo query body

### DIFF
--- a/api/src/routes/v1/matches/demo/live_query.rs
+++ b/api/src/routes/v1/matches/demo/live_query.rs
@@ -8,16 +8,17 @@
 use core::convert::Infallible;
 use core::time::Duration;
 
+use axum::Json;
 use axum::extract::{Query, State};
-use axum::response::IntoResponse;
 use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
 use datafusion::arrow::json::LineDelimitedWriter;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::execution::SendableRecordBatchStream;
 use futures::{Stream, StreamExt};
 use reqwest::StatusCode;
 use serde::Deserialize;
-use utoipa::IntoParams;
+use utoipa::{IntoParams, ToSchema};
 
 use super::demofusion;
 use crate::context::AppState;
@@ -34,9 +35,50 @@ pub(super) struct LiveQueryParams {
     /// are given. Resolving a match spectates its lobby and is rate-limited.
     #[serde(default)]
     match_id: Option<u64>,
-    /// Explicit broadcast base URL (from `/live/urls`). Provide this or `match_id`.
+    /// Explicit broadcast base URL (from `/live/urls`). Prefer POST when passing a URL so it is not
+    /// embedded in access logs, browser history, or intermediary caches.
     #[serde(default)]
     broadcast_url: Option<String>,
+}
+
+#[derive(Deserialize, ToSchema)]
+pub(super) struct LiveQueryRequest {
+    /// SQL query to run over the broadcast's entity/event tables (see `/demo/schema`).
+    query: String,
+    /// Match to spectate and stream. Provide this or `broadcast_url`; `broadcast_url` wins if both
+    /// are given. Resolving a match spectates its lobby and is rate-limited.
+    #[serde(default)]
+    match_id: Option<u64>,
+    /// Explicit broadcast base URL (from `/live/urls`). Kept in the request body instead of the
+    /// query string to avoid leaking transient broadcast tokens through URLs.
+    #[serde(default)]
+    broadcast_url: Option<String>,
+}
+
+struct LiveQueryInput {
+    query: String,
+    match_id: Option<u64>,
+    broadcast_url: Option<String>,
+}
+
+impl From<LiveQueryParams> for LiveQueryInput {
+    fn from(params: LiveQueryParams) -> Self {
+        Self {
+            query: params.query,
+            match_id: params.match_id,
+            broadcast_url: params.broadcast_url,
+        }
+    }
+}
+
+impl From<LiveQueryRequest> for LiveQueryInput {
+    fn from(req: LiveQueryRequest) -> Self {
+        Self {
+            query: req.query,
+            match_id: req.match_id,
+            broadcast_url: req.broadcast_url,
+        }
+    }
 }
 
 #[utoipa::path(
@@ -60,7 +102,8 @@ Run a SQL query over a match's **live** broadcast and stream result rows over Se
 the match plays, instead of waiting for the demo to finish (see the async `/demo/query`).
 
 Provide either `match_id` (the server spectates the lobby to obtain the broadcast URL) or an explicit
-`broadcast_url` from `/live/urls`.
+`broadcast_url` from `/live/urls`. Prefer `POST /live/query` when passing `broadcast_url`, so the
+transient URL is not embedded in access logs, browser history, or intermediary caches.
 
 Projection/filter queries emit rows continuously as they are decoded. A whole-match aggregation
 (`GROUP BY` / `ORDER BY`) can only produce its final rows once the broadcast ends.
@@ -74,9 +117,56 @@ Projection/filter queries emit rows continuously as they are decoded. A whole-ma
 )]
 pub(super) async fn live_query(
     rate_limit_key: RateLimitKey,
-    State(mut state): State<AppState>,
+    State(state): State<AppState>,
     Query(params): Query<LiveQueryParams>,
 ) -> APIResult<impl IntoResponse> {
+    live_query_response(rate_limit_key, state, params.into()).await
+}
+
+#[utoipa::path(
+    post,
+    path = "/live/query",
+    request_body = LiveQueryRequest,
+    responses(
+        (status = OK, content_type = "text/event-stream", description = "\
+SSE stream of result rows. Each `message` event's `data` is one result row as a JSON object; a \
+terminal `end` event marks the end of the broadcast, and an `error` event carries any mid-stream \
+failure."),
+        (status = BAD_REQUEST, description = "Neither match_id nor broadcast_url given, or the query is invalid."),
+        (status = TOO_MANY_REQUESTS, description = "Rate limit exceeded"),
+        (status = BAD_GATEWAY, description = "The live broadcast could not be fetched"),
+        (status = INTERNAL_SERVER_ERROR, description = "Failed to start the live query")
+    ),
+    tags = ["Demo"],
+    summary = "Live Demo Query (SSE, POST)",
+    description = "
+Run a SQL query over a match's **live** broadcast and stream result rows over Server-Sent Events as
+the match plays. This POST variant is preferred when passing an explicit `broadcast_url`, because the
+transient URL stays in the request body instead of the URL/query string.
+
+Provide either `match_id` (the server spectates the lobby to obtain the broadcast URL) or an explicit
+`broadcast_url` from `/live/urls`.
+
+### Rate Limits:
+| Type | Limit |
+| ---- | ----- |
+| IP | 10req/m |
+| Global | 60req/m |
+"
+)]
+pub(super) async fn live_query_post(
+    rate_limit_key: RateLimitKey,
+    State(state): State<AppState>,
+    Json(req): Json<LiveQueryRequest>,
+) -> APIResult<impl IntoResponse> {
+    live_query_response(rate_limit_key, state, req.into()).await
+}
+
+async fn live_query_response(
+    rate_limit_key: RateLimitKey,
+    mut state: AppState,
+    input: LiveQueryInput,
+) -> APIResult<Response> {
     state
         .rate_limit_client
         .apply_limits(
@@ -89,7 +179,7 @@ pub(super) async fn live_query(
         )
         .await?;
 
-    let broadcast_url = match (params.broadcast_url, params.match_id) {
+    let broadcast_url = match (input.broadcast_url, input.match_id) {
         (Some(url), _) => url,
         (None, Some(match_id)) => {
             resolve_broadcast_url(&mut state, &rate_limit_key, match_id)
@@ -104,11 +194,13 @@ pub(super) async fn live_query(
         }
     };
 
-    let stream = demofusion::query_live(&broadcast_url, &params.query)
+    let stream = demofusion::query_live(&broadcast_url, &input.query)
         .await
         .map_err(|e| super::format::map_demofusion_err(&e))?;
 
-    Ok(Sse::new(sse_rows(stream)).keep_alive(KeepAlive::default()))
+    Ok(Sse::new(sse_rows(stream))
+        .keep_alive(KeepAlive::default())
+        .into_response())
 }
 
 /// Adapt a result-batch stream into an SSE row stream: one `message` event per row, a terminal

--- a/api/src/routes/v1/matches/demo/mod.rs
+++ b/api/src/routes/v1/matches/demo/mod.rs
@@ -69,4 +69,5 @@ pub(super) fn router() -> OpenApiRouter<AppState> {
         .routes(routes!(submit::submit))
         .routes(routes!(status::status))
         .routes(routes!(live_query::live_query))
+        .routes(routes!(live_query::live_query_post))
 }


### PR DESCRIPTION
## Summary
- Adds a POST variant for `/v1/matches/demo/live/query` using a JSON body.
- Keeps the existing GET route for compatibility.
- Documents that POST is preferred when passing an explicit `broadcast_url`, so transient broadcast tokens are not embedded in query strings, browser history, or access logs.

## Base / dependency note
This branch is built on top of `f1849fd5960518f7c22d4b12bd85d6eb9e5b881d` (`feat(api): Add Live Demo support`). That commit is visible in this repository but is not currently on `master` or any branch I can target directly, so GitHub will show the live-demo commit in this PR until that base lands or a branch containing it is available.

## Test plan
- `cargo fmt --manifest-path api/Cargo.toml --check`
- `git diff --check`
- `PATH="$PATH:/c/Users/User/AppData/Local/bin/NASM:/c/Program Files/LLVM/bin" LIBCLANG_PATH="/c/Program Files/LLVM/bin" rustup run 1.96-x86_64-pc-windows-msvc cargo check --manifest-path api/Cargo.toml --lib -q`

Note: full binary `cargo check` on Windows still hits the existing baseline `tokio::signal::unix` import in `src/main.rs`; `--lib` validates the API route/module code touched here.
