### PR TITLE
fix(api): flush sparse live demo query batches by time

### DIFF
--- a/api/src/routes/v1/matches/demo/demofusion/live.rs
+++ b/api/src/routes/v1/matches/demo/demofusion/live.rs
@@ -8,6 +8,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Read};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use datafusion::arrow::datatypes::SchemaRef;
@@ -39,6 +40,11 @@ use super::query::{
 };
 use super::table_extractor::extract_table_names;
 use super::visitor::{BroadcastDemoStream, discover_schemas_from_demo};
+
+/// Flush a table's builder once this many rows have accumulated: bounds batch size.
+const FLUSH_ROWS: usize = 1024;
+/// Flush partial batches at least this often, so sparse live queries don't wait for 1024 rows.
+const FLUSH_INTERVAL: Duration = Duration::from_millis(250);
 
 /// Run `query` over a live GOTV/spectator broadcast, streaming result rows as the match plays.
 ///
@@ -141,6 +147,7 @@ pub(crate) async fn query_live(base_url: &str, query: &str) -> Result<SendableRe
         entities,
         events,
         pending: 0,
+        last_flush: Instant::now(),
     };
     tokio::task::spawn_blocking(move || {
         let stream = LiveBroadcastStream::new(bytes_rx);
@@ -218,19 +225,20 @@ impl PartitionStream for ChannelPartition {
     }
 }
 
-/// Flush a table's builder once this many rows have accumulated: bounds batch size and staleness.
-const FLUSH_ROWS: usize = 1024;
-
 struct StreamingCollector {
     entities: HashMap<u64, Channel<EntityBatchBuilder>>,
     events: HashMap<u32, Channel<EventBatchBuilder>>,
     pending: usize,
+    last_flush: Instant,
 }
 
 impl StreamingCollector {
-    /// Send each table's accumulated batch. `force` flushes below the row threshold (the final tail).
+    /// Send each table's accumulated batch. `force` flushes below the row/time threshold.
     fn flush(&mut self, force: bool) -> Result<()> {
-        if !force && self.pending < FLUSH_ROWS {
+        if self.pending == 0 {
+            return Ok(());
+        }
+        if !force && self.pending < FLUSH_ROWS && self.last_flush.elapsed() < FLUSH_INTERVAL {
             return Ok(());
         }
         for ch in self.entities.values_mut() {
@@ -240,6 +248,7 @@ impl StreamingCollector {
             send_batch(ch.builder.finish()?, &ch.tx)?;
         }
         self.pending = 0;
+        self.last_flush = Instant::now();
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Flushes live demo query batches by time as well as row count.
- Prevents sparse projection/filter queries from waiting for `1024` decoded rows before emitting.
- Also makes client disconnects observable sooner because pending rows are flushed periodically.

## Base / dependency note
This branch is built on top of `f1849fd5960518f7c22d4b12bd85d6eb9e5b881d` (`feat(api): Add Live Demo support`). That commit is visible in this repository but is not currently on `master` or any branch I can target directly, so GitHub will show the live-demo commit in this PR until that base lands or a branch containing it is available.

## Test plan
- `cargo fmt --manifest-path api/Cargo.toml --check`
- `git diff --check`
- `PATH="$PATH:/c/Users/User/AppData/Local/bin/NASM:/c/Program Files/LLVM/bin" LIBCLANG_PATH="/c/Program Files/LLVM/bin" rustup run 1.96-x86_64-pc-windows-msvc cargo check --manifest-path api/Cargo.toml --lib -q`

Note: full binary `cargo check` on Windows still hits the existing baseline `tokio::signal::unix` import in `src/main.rs`; `--lib` validates the API route/module code touched here.
