### PR TITLE
fix(api): tolerate transient live broadcast fragment errors

### DIFF
--- a/api/src/routes/v1/matches/demo/demofusion/live.rs
+++ b/api/src/routes/v1/matches/demo/demofusion/live.rs
@@ -28,6 +28,8 @@ use haste_core::valveprotos::common::{
     CDemoClassInfo, CDemoFullPacket, CDemoPacket, CDemoSendTables, EDemoCommands,
 };
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+use tokio::time::{Duration, sleep};
+use tracing::warn;
 
 use super::entity_batch_builder::EntityBatchBuilder;
 use super::error::{Error, Result};
@@ -39,6 +41,13 @@ use super::query::{
 };
 use super::table_extractor::extract_table_names;
 use super::visitor::{BroadcastDemoStream, discover_schemas_from_demo};
+
+/// Number of consecutive broadcast fragment errors tolerated before ending the live stream.
+const MAX_CONSECUTIVE_BROADCAST_ERRORS: usize = 3;
+/// Short pause before retrying after a transient fragment fetch error.
+const BROADCAST_ERROR_BACKOFF: Duration = Duration::from_millis(250);
+/// Flush a table's builder once this many rows have accumulated: bounds batch size and staleness.
+const FLUSH_ROWS: usize = 1024;
 
 /// Run `query` over a live GOTV/spectator broadcast, streaming result rows as the match plays.
 ///
@@ -130,9 +139,28 @@ pub(crate) async fn query_live(base_url: &str, query: &str) -> Result<SendableRe
 
     // Producer: forward each remaining fragment; dropping the sender on exit signals EOF to the parser.
     tokio::spawn(async move {
-        while let Some(Ok(bytes)) = http.next_packet().await {
-            if bytes_tx.send(bytes).is_err() {
-                break;
+        let mut consecutive_errors = 0usize;
+        loop {
+            match http.next_packet().await {
+                Some(Ok(bytes)) => {
+                    consecutive_errors = 0;
+                    if bytes_tx.send(bytes).is_err() {
+                        break;
+                    }
+                }
+                Some(Err(e)) => {
+                    consecutive_errors += 1;
+                    warn!(
+                        error = %e,
+                        consecutive_errors,
+                        "live broadcast fragment fetch failed"
+                    );
+                    if consecutive_errors >= MAX_CONSECUTIVE_BROADCAST_ERRORS {
+                        break;
+                    }
+                    sleep(BROADCAST_ERROR_BACKOFF).await;
+                }
+                None => break,
             }
         }
     });
@@ -217,9 +245,6 @@ impl PartitionStream for ChannelPartition {
         ))
     }
 }
-
-/// Flush a table's builder once this many rows have accumulated: bounds batch size and staleness.
-const FLUSH_ROWS: usize = 1024;
 
 struct StreamingCollector {
     entities: HashMap<u64, Channel<EntityBatchBuilder>>,


### PR DESCRIPTION
## Summary
- Logs live broadcast fragment fetch errors instead of silently terminating on the first one.
- Tolerates a small number of consecutive transient fragment failures with a short backoff before ending the stream.

## Base / dependency note
This branch is built on top of `f1849fd5960518f7c22d4b12bd85d6eb9e5b881d` (`feat(api): Add Live Demo support`). That commit is visible in this repository but is not currently on `master` or any branch I can target directly, so GitHub will show the live-demo commit in this PR until that base lands or a branch containing it is available.

## Test plan
- `cargo fmt --manifest-path api/Cargo.toml --check`
- `git diff --check`
- `PATH="$PATH:/c/Users/User/AppData/Local/bin/NASM:/c/Program Files/LLVM/bin" LIBCLANG_PATH="/c/Program Files/LLVM/bin" rustup run 1.96-x86_64-pc-windows-msvc cargo check --manifest-path api/Cargo.toml --lib -q`

Note: full binary `cargo check` on Windows still hits the existing baseline `tokio::signal::unix` import in `src/main.rs`; `--lib` validates the API route/module code touched here.
