### PR TITLE
Flush live demo rows instantly instead of buffering 1024

### DIFF
--- a/api/src/routes/v1/matches/demo/demofusion/live.rs
+++ b/api/src/routes/v1/matches/demo/demofusion/live.rs
@@ -145,17 +145,13 @@ pub(crate) async fn query_live(base_url: &str, query: &str) -> Result<SendableRe
         }
     });
 
-    let visitor = StreamingCollector {
-        entities,
-        events,
-        pending: 0,
-    };
+    let visitor = StreamingCollector { entities, events };
     tokio::task::spawn_blocking(move || {
         let stream = LiveBroadcastStream::new(bytes_rx);
         if let Ok(mut parser) = Parser::from_stream_with_visitor(stream, visitor) {
             // A parse error (truncated tail) or a closed result stream just ends the live query.
             let _ = parser.run_to_end();
-            let _ = parser.into_visitor().flush(true);
+            let _ = parser.into_visitor().flush();
         }
     });
 
@@ -226,28 +222,21 @@ impl PartitionStream for ChannelPartition {
     }
 }
 
-/// Flush a table's builder once this many rows have accumulated: bounds batch size and staleness.
-const FLUSH_ROWS: usize = 1024;
-
 struct StreamingCollector {
     entities: HashMap<u64, Channel<EntityBatchBuilder>>,
     events: HashMap<u32, Channel<EventBatchBuilder>>,
-    pending: usize,
 }
 
 impl StreamingCollector {
-    /// Send each table's accumulated batch. `force` flushes below the row threshold (the final tail).
-    fn flush(&mut self, force: bool) -> Result<()> {
-        if !force && self.pending < FLUSH_ROWS {
-            return Ok(());
-        }
+    /// Send each table's accumulated batch immediately. Empty builders are skipped by `send_batch`,
+    /// so rows flow out as soon as they are decoded (flushed every tick) with no buffering delay.
+    fn flush(&mut self) -> Result<()> {
         for ch in self.entities.values_mut() {
             send_batch(ch.builder.finish()?, &ch.tx)?;
         }
         for ch in self.events.values_mut() {
             send_batch(ch.builder.finish()?, &ch.tx)?;
         }
-        self.pending = 0;
         Ok(())
     }
 }
@@ -266,7 +255,6 @@ impl Visitor for StreamingCollector {
         {
             ch.builder
                 .append_entity(ctx.tick(), entity.index(), delta, entity);
-            self.pending += 1;
         }
         Ok(())
     }
@@ -276,13 +264,12 @@ impl Visitor for StreamingCollector {
             && let Some(event) = decode_event(packet_type, data)
         {
             ch.builder.append(ctx.tick(), &event);
-            self.pending += 1;
         }
         Ok(())
     }
 
     fn on_tick_end(&mut self, _ctx: &Context) -> Result<()> {
-        self.flush(false)
+        self.flush()
     }
 }
 


### PR DESCRIPTION
## Description
The live GOTV/spectator broadcast streaming collector (`api/src/routes/v1/matches/demo/demofusion/live.rs`) buffered decoded rows and only sent them to the result stream once **1024 rows** had accumulated (the `FLUSH_ROWS` threshold, tracked via a `pending` counter). This meant live query results lagged behind the match until a batch filled up.

This PR removes the row-count threshold so rows flow out **as soon as they are decoded**:
- Removed the `FLUSH_ROWS` constant and the `pending` counter field.
- `flush()` now always sends each table's accumulated builder; it's called on every `on_tick_end`, so rows are emitted per tick.
- Empty builders are already skipped by `send_batch` (`num_rows() > 0` guard), so per-tick flushing stays cheap.
- Simplified `flush()` signature (dropped the `force` param, since there's no longer a threshold to override).

## Related Issue
N/A

## Type of Change
- [x] Performance improvement
- [x] Code refactoring (no functional changes)

## How Has This Been Tested?
- [x] Manual testing — `cargo check --lib` compiles cleanly with the change.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes
Rows still flush at tick boundaries (the natural unit of the broadcast), which is the earliest point decoded rows for a tick are complete — so results are now delivered ASAP with no fixed-size buffering delay.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKDLjEFosPpkVm9BU3doek)_