### PR TITLE
Update Rust toolchain to 1.97

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 pnpm = "11.6.0"
-rust = "1.96"
+rust = "1.97"
 java = "temurin-21"
 uv = "latest"
 lefthook = "latest"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,6 @@
 ARG EXE_NAME=deadlock-api-rust
 
-FROM rust:1.96-slim-trixie AS builder
+FROM rust:1.97-slim-trixie AS builder
 ARG EXE_NAME
 RUN apt-get update \
     && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev ca-certificates gcc libssl-dev pkg-config cmake build-essential clang curl mold git \

--- a/api/rust-toolchain.toml
+++ b/api/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96"
+channel = "1.97"

--- a/api/src/routes/v1/matches/demo/demofusion/visitor/mod.rs
+++ b/api/src/routes/v1/matches/demo/demofusion/visitor/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::std_instead_of_core)]
+
 mod collecting_visitor;
 mod schema_discovery;
 

--- a/api/src/routes/v1/matches/demo/schema.rs
+++ b/api/src/routes/v1/matches/demo/schema.rs
@@ -157,6 +157,7 @@ pub(super) async fn schema(
 ///
 /// A demo's schema is immutable, so results are cached for 24h keyed on the demo URL,
 /// matching the endpoint's `Cache-Control`.
+#[allow(clippy::std_instead_of_core)]
 async fn fetch_demo_schema(url: &str) -> Result<Vec<TableSchema>, APIError> {
     let response = HTTP_CLIENT
         .get(url)

--- a/api/src/services/assets/versions/items/build.rs
+++ b/api/src/services/assets/versions/items/build.rs
@@ -1096,6 +1096,7 @@ mod tests {
     const SNAPSHOT_VERSION: u32 = 6064;
     const PUBLIC_BASE: &str = "https://assets-bucket.deadlock-api.com/assets-api-res/versions";
 
+    #[allow(clippy::std_instead_of_core)]
     async fn fetch_zst(client: &reqwest::Client, version: u32, rel: &str) -> String {
         use async_compression::tokio::bufread::ZstdDecoder;
         use tokio::io::AsyncReadExt;

--- a/api/src/services/assets/versions/store.rs
+++ b/api/src/services/assets/versions/store.rs
@@ -148,6 +148,7 @@ async fn fetch_decompressed_cached(
 }
 
 /// Fetch a zstd-compressed object by its full bucket key and decompress it.
+#[allow(clippy::std_instead_of_core)]
 pub(crate) async fn fetch_zst(r2: &AmazonS3, key: &str) -> Result<Bytes, VersionStoreError> {
     debug!("Fetching asset: {key}");
     let res = r2.get(&ObjectPath::from(key.to_owned())).await?;

--- a/live-events/Dockerfile
+++ b/live-events/Dockerfile
@@ -1,6 +1,6 @@
 ARG EXE_NAME=deadlock-live-events
 
-FROM rust:1.96-slim-trixie AS chef
+FROM rust:1.97-slim-trixie AS chef
 RUN apt-get update \
     && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev sccache ca-certificates gcc libssl-dev pkg-config cmake build-essential curl
 RUN cargo install --locked cargo-chef

--- a/live-events/rust-toolchain.toml
+++ b/live-events/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96"
+channel = "1.97"

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.96-slim-trixie AS builder
+FROM rust:1.97-slim-trixie AS builder
 RUN apt-get update \
     && apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev ca-certificates gcc libssl-dev pkg-config cmake build-essential clang curl git mold \
     && rm -rf /var/lib/apt/lists/*

--- a/tools/hltv-scraper/src/hltv/hltv_extract_meta.rs
+++ b/tools/hltv-scraper/src/hltv/hltv_extract_meta.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::std_instead_of_core)]
+
 use std::io::Cursor;
 use std::sync::Arc;
 

--- a/tools/rust-toolchain.toml
+++ b/tools/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.96"
+channel = "1.97"


### PR DESCRIPTION
Bumps the pinned Rust toolchain from 1.96 to 1.97 (newest stable is 1.97.1, released 2026-07-14).

## Version pins

- `api/rust-toolchain.toml`, `tools/rust-toolchain.toml`, `live-events/rust-toolchain.toml`
- `.mise.toml`
- `api/Dockerfile`, `tools/Dockerfile`, `live-events/Dockerfile` → `rust:1.97-slim-trixie`

`Cargo.lock` is unchanged in all three workspaces.

## Lint fallout

Clippy 1.97's `std_instead_of_core` now fires on `std::io::Cursor` and suggests `core::io::Cursor` — but `core::io` is still behind the unstable `core_io` feature, so the suggested fix does not compile. Since `api` and the tools crates `#![deny]` that lint, this broke the build. Added `#[allow(clippy::std_instead_of_core)]` at the affected sites:

- `api/src/routes/v1/matches/demo/demofusion/visitor/mod.rs`
- `api/src/routes/v1/matches/demo/schema.rs`
- `api/src/services/assets/versions/store.rs`
- `api/src/services/assets/versions/items/build.rs`
- `tools/hltv-scraper/src/hltv/hltv_extract_meta.rs`

The attribute placement is load-bearing: a statement-level `#[allow]` is silently ignored for this lint (the level is resolved against the enclosing item), and an `#[allow]` on a `use` trips `clippy::useless_attribute` — hence module-level inner attributes for the import sites and function-level for the inline ones.

## Verification

`cargo fmt` (no changes) and `cargo clippy --all-targets --all-features --locked` pass on 1.97.1 for `api/`, `tools/`, and `live-events/`. Tests were not run locally; leaving those to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)