### PR TITLE
feat(website): add EDL.GG to sponsors section

### DIFF
--- a/website/public/_headers
+++ b/website/public/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com https://challenges.cloudflare.com https://eu-assets.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://assets-bucket.deadlock-api.com data:; connect-src 'self' https://api.deadlock-api.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://stats.g.doubleclick.net; font-src 'self'; frame-src https://challenges.cloudflare.com;
+  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com https://challenges.cloudflare.com https://eu-assets.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' https://assets-bucket.deadlock-api.com https://media.edl.gg data:; connect-src 'self' https://api.deadlock-api.com https://eu.i.posthog.com https://eu-assets.i.posthog.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://stats.g.doubleclick.net; font-src 'self'; frame-src https://challenges.cloudflare.com;
 
 /streamkit/widgets/*
   X-Frame-Options: ALLOWALL

--- a/website/src/routes/index.tsx
+++ b/website/src/routes/index.tsx
@@ -208,7 +208,7 @@ const mainSponsor = {
   height: 140,
 };
 
-const sponsors = [
+const sponsors: { href: string; title: string; logo: string; width?: number; height?: number }[] = [
   {
     href: "https://statlocker.gg/?ref=deadlock-api.com",
     title: "Statlocker.GG",
@@ -222,6 +222,11 @@ const sponsors = [
     logo: "/logo/blast.svg",
     width: 996,
     height: 188,
+  },
+  {
+    href: "https://edl.gg/?ref=deadlock-api.com",
+    title: "EDL.GG",
+    logo: "https://media.edl.gg/gallery/organizer/3aa64a56-2d98-4eec-a1f6-e0d69fbd7e03/image.webp?v=1787256639789",
   },
 ];
 


### PR DESCRIPTION
## Description

Adds EDL.GG to the "Our Sponsors" section on the website landing page, linking to `https://edl.gg/?ref=deadlock-api.com` (matching the `?ref=` convention used by the other sponsor links).

Changes:
- `website/src/routes/index.tsx` — new entry in the `sponsors` array; the array now carries an explicit type so `width`/`height` are optional.
- `website/public/_headers` — added the logo's host to the CSP `img-src` allowlist.

**Known gap, needs a follow-up before merge:** the logo is currently referenced by its remote URL instead of being self-hosted under `website/public/logo/` like `deadchaps.png`, `statlocker.png`, and `blast.svg`. The asset host is blocked by the network egress policy of the environment this branch was developed in, so the file could not be downloaded, inspected, or committed. Two consequences:

1. The image's transparency, colors against the dark theme, and intrinsic dimensions were **not** visually verified — `width`/`height` are omitted for this entry, so no aspect ratio is reserved (the `max-h-10 max-w-[140px] object-contain` classes still constrain the rendered size).
2. The CSP `img-src` change is only needed because of the remote reference. If the logo is committed to `public/logo/` and the `logo` field switched to a local path, that `_headers` change should be reverted.

## Related Issue

N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

Not tested. Dependencies could not be installed in the development environment, so `pnpm lint`, `pnpm typecheck`, and a local render were not run. The change is a data-only addition to an existing rendered array plus a header string edit.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)

None — the logo could not be fetched or rendered in this environment.

## Additional Notes

To finish this properly: save the logo as `website/public/logo/edl.webp`, change the `logo` field to `/logo/edl.webp`, fill in its real `width`/`height`, and revert the `_headers` CSP change.

---
_Generated by [Claude Code](https://claude.ai/code/session_015oRmM26EnzEr1bL6UTdVms)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added EDL.GG to the homepage sponsor list.
  * Added support for displaying the sponsor’s hosted logo image.

* **Bug Fixes**
  * Updated image security settings to allow approved sponsor media to load correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->