### PR TITLE
Add rank sort to the player scoreboard

### DIFF
--- a/api/src/routes/v1/analytics/hero_scoreboard.rs
+++ b/api/src/routes/v1/analytics/hero_scoreboard.rs
@@ -197,8 +197,6 @@ async fn get_hero_scoreboard(
     description = "
 This endpoint returns the hero scoreboard.
 
-`sort_by=rank` is rejected here: a rank belongs to a player, use the player scoreboard for it.
-
 ### Rate Limits:
 > The rate limits below are **shared across all analytics endpoints**.
 
@@ -221,7 +219,6 @@ pub(super) async fn hero_scoreboard(
             message: "Cannot filter by average badge for street brawl game mode".to_string(),
         });
     }
-    // A rank belongs to a player, not to a hero, so there is nothing to sort heroes by.
     if query.sort_by == ScoreboardQuerySortBy::Rank {
         return Err(APIError::status_msg(
             StatusCode::BAD_REQUEST,

--- a/api/src/routes/v1/analytics/hero_scoreboard.rs
+++ b/api/src/routes/v1/analytics/hero_scoreboard.rs
@@ -197,6 +197,8 @@ async fn get_hero_scoreboard(
     description = "
 This endpoint returns the hero scoreboard.
 
+`sort_by=rank` is rejected here: a rank belongs to a player, use the player scoreboard for it.
+
 ### Rate Limits:
 > The rate limits below are **shared across all analytics endpoints**.
 
@@ -218,6 +220,13 @@ pub(super) async fn hero_scoreboard(
             status: StatusCode::BAD_REQUEST,
             message: "Cannot filter by average badge for street brawl game mode".to_string(),
         });
+    }
+    // A rank belongs to a player, not to a hero, so there is nothing to sort heroes by.
+    if query.sort_by == ScoreboardQuerySortBy::Rank {
+        return Err(APIError::status_msg(
+            StatusCode::BAD_REQUEST,
+            "sort_by=rank is only supported by the player scoreboard",
+        ));
     }
     #[allow(deprecated)]
     filter_protected_accounts(&state, &mut query.account_ids, query.account_id).await?;

--- a/api/src/routes/v1/analytics/player_scoreboard.rs
+++ b/api/src/routes/v1/analytics/player_scoreboard.rs
@@ -129,8 +129,10 @@ fn from_clause_parts(
     } else {
         let inner_projection = query
             .sort_by
-            .inner_column()
-            .map_or(String::new(), |col| format!(", any({col}) as {col}"));
+            .inner_columns()
+            .iter()
+            .map(|col| format!(", any({col}) as {col}"))
+            .join("");
         (
             format!(
                 "
@@ -269,6 +271,12 @@ async fn get_player_scoreboard(
     description = "
 This endpoint returns the player scoreboard.
 
+`sort_by=rank` sorts players by the rank badge Valve reported at the end of their latest ranked
+match inside the filtered range, i.e. the rank they entered that match with plus the progress it
+awarded. Combined with `hero_id` and a time range it answers \"who are the highest ranked players
+on this hero right now\" without having to pick a badge range by hand. Only ranked matches carry a
+rank, so players without one in range come back with a `value` of `0`.
+
 ### Rate Limits:
 > The rate limits below are **shared across all analytics endpoints**.
 
@@ -295,6 +303,56 @@ pub(crate) async fn player_scoreboard(
     get_player_scoreboard(&state.ch_client_cached, query)
         .await
         .map(Json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::proptest_utils::assert_valid_sql;
+
+    /// The dedup subquery has to carry both rank columns through, otherwise the outer
+    /// `argMaxIf` has nothing to read.
+    #[test]
+    fn rank_sort_carries_both_rank_columns_through_the_dedup_subquery() {
+        let sql = build_query(&PlayerScoreboardQuery {
+            sort_by: ScoreboardQuerySortBy::Rank,
+            // hero_id forces the inline dedup path over FINAL.
+            hero_id: Some(15),
+            ..Default::default()
+        });
+        assert_valid_sql(&sql);
+        assert!(
+            sql.contains(
+                ", any(player_rank_final_flat_progress) as player_rank_final_flat_progress"
+            )
+        );
+        assert!(sql.contains(
+            ", any(player_rank_initial_display_rank) as player_rank_initial_display_rank"
+        ));
+        assert!(sql.contains("argMaxIf(player_rank_final_flat_progress, match_id"));
+    }
+
+    #[test]
+    fn rank_sort_is_valid_sql_on_the_final_path() {
+        let sql = build_query(&PlayerScoreboardQuery {
+            sort_by: ScoreboardQuerySortBy::Rank,
+            ..Default::default()
+        });
+        assert_valid_sql(&sql);
+        assert!(sql.contains("FROM match_player FINAL"));
+        assert!(sql.contains("argMaxIf(player_rank_final_flat_progress, match_id"));
+    }
+
+    /// Players with no ranked match in range sort as unranked rather than blowing up the
+    /// non-nullable `value` column.
+    #[test]
+    fn rank_sort_falls_back_to_zero_when_no_ranked_match_is_in_range() {
+        let sql = build_query(&PlayerScoreboardQuery {
+            sort_by: ScoreboardQuerySortBy::Rank,
+            ..Default::default()
+        });
+        assert!(sql.contains("IS NULL, 0,"));
+    }
 }
 
 #[cfg(test)]

--- a/api/src/routes/v1/analytics/player_scoreboard.rs
+++ b/api/src/routes/v1/analytics/player_scoreboard.rs
@@ -271,12 +271,6 @@ async fn get_player_scoreboard(
     description = "
 This endpoint returns the player scoreboard.
 
-`sort_by=rank` sorts players by the rank badge Valve reported at the end of their latest ranked
-match inside the filtered range, i.e. the rank they entered that match with plus the progress it
-awarded. Combined with `hero_id` and a time range it answers \"who are the highest ranked players
-on this hero right now\" without having to pick a badge range by hand. Only ranked matches carry a
-rank, so players without one in range come back with a `value` of `0`.
-
 ### Rate Limits:
 > The rate limits below are **shared across all analytics endpoints**.
 
@@ -310,8 +304,6 @@ mod tests {
     use super::*;
     use crate::utils::proptest_utils::assert_valid_sql;
 
-    /// The dedup subquery has to carry both rank columns through, otherwise the outer
-    /// `argMaxIf` has nothing to read.
     #[test]
     fn rank_sort_carries_both_rank_columns_through_the_dedup_subquery() {
         let sql = build_query(&PlayerScoreboardQuery {
@@ -343,8 +335,6 @@ mod tests {
         assert!(sql.contains("argMaxIf(player_rank_final_flat_progress, match_id"));
     }
 
-    /// Players with no ranked match in range sort as unranked rather than blowing up the
-    /// non-nullable `value` column.
     #[test]
     fn rank_sort_falls_back_to_zero_when_no_ranked_match_is_in_range() {
         let sql = build_query(&PlayerScoreboardQuery {

--- a/api/src/routes/v1/analytics/scoreboard_types.rs
+++ b/api/src/routes/v1/analytics/scoreboard_types.rs
@@ -12,8 +12,7 @@ pub enum ScoreboardQuerySortBy {
     /// Sort by the number of matches
     #[default]
     Matches,
-    /// Sort by the rank badge (tier = first digits, subtier = last digit) the player ended their
-    /// latest ranked match in the filtered range on. Only supported by the player scoreboard.
+    /// Sort by the rank badge of the player's latest ranked match. Player scoreboard only.
     Rank,
     /// Sort by the number of wins
     Wins,
@@ -137,13 +136,8 @@ pub enum ScoreboardQuerySortBy {
     HeroBulletsHitCrit,
 }
 
-/// `ClickHouse` expression for the badge a player ended their latest ranked match on, i.e. the
-/// rank they entered it with plus the progress it awarded. `0` when none of the grouped rows
-/// carries a rank.
-///
-/// Only ranked matches report a rank, and `initial_display_rank` stays `0` for the whole of
-/// placement, so those rows must not contribute a badge — hence the `-If` guard rather than a
-/// plain `argMax`.
+/// Badge the player ended their latest ranked match on, `0` when no grouped row carries a rank.
+/// `initial_display_rank` stays `0` through placement, so those rows must not contribute a badge.
 fn latest_badge_clause() -> String {
     let latest_progress = "argMaxIf(player_rank_final_flat_progress, match_id, \
                            ifNull(player_rank_initial_display_rank, 0) > 0)";
@@ -154,7 +148,6 @@ fn latest_badge_clause() -> String {
 impl ScoreboardQuerySortBy {
     pub(super) fn get_select_clause(self) -> String {
         let clause = match self {
-            // Not a plain aggregate: the badge is read off the player's latest ranked row.
             Self::Rank => return latest_badge_clause(),
             Self::Matches => "uniq(match_id)",
             Self::Wins => "countIf(won)",

--- a/api/src/routes/v1/analytics/scoreboard_types.rs
+++ b/api/src/routes/v1/analytics/scoreboard_types.rs
@@ -2,6 +2,8 @@ use serde::Deserialize;
 use strum::Display;
 use utoipa::ToSchema;
 
+use crate::routes::v1::players::rank::badge_from_flat_progress_sql;
+
 #[derive(Copy, Clone, Debug, Deserialize, ToSchema, Display, Eq, PartialEq, Hash, Default)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(rename_all = "snake_case")]
@@ -10,6 +12,9 @@ pub enum ScoreboardQuerySortBy {
     /// Sort by the number of matches
     #[default]
     Matches,
+    /// Sort by the rank badge (tier = first digits, subtier = last digit) the player ended their
+    /// latest ranked match in the filtered range on. Only supported by the player scoreboard.
+    Rank,
     /// Sort by the number of wins
     Wins,
     /// Sort by the number of losses
@@ -132,9 +137,25 @@ pub enum ScoreboardQuerySortBy {
     HeroBulletsHitCrit,
 }
 
+/// `ClickHouse` expression for the badge a player ended their latest ranked match on, i.e. the
+/// rank they entered it with plus the progress it awarded. `0` when none of the grouped rows
+/// carries a rank.
+///
+/// Only ranked matches report a rank, and `initial_display_rank` stays `0` for the whole of
+/// placement, so those rows must not contribute a badge — hence the `-If` guard rather than a
+/// plain `argMax`.
+fn latest_badge_clause() -> String {
+    let latest_progress = "argMaxIf(player_rank_final_flat_progress, match_id, \
+                           ifNull(player_rank_initial_display_rank, 0) > 0)";
+    let badge = badge_from_flat_progress_sql(&format!("assumeNotNull({latest_progress})"));
+    format!("if({latest_progress} IS NULL, 0, {badge})")
+}
+
 impl ScoreboardQuerySortBy {
-    pub(super) fn get_select_clause(self) -> &'static str {
-        match self {
+    pub(super) fn get_select_clause(self) -> String {
+        let clause = match self {
+            // Not a plain aggregate: the badge is read off the player's latest ranked row.
+            Self::Rank => return latest_badge_clause(),
             Self::Matches => "uniq(match_id)",
             Self::Wins => "countIf(won)",
             Self::Losses => "countIf(not won)",
@@ -196,7 +217,8 @@ impl ScoreboardQuerySortBy {
             Self::MaxHeroBulletsHitCritPerMatch => "max(max_hero_bullets_hit_crit)",
             Self::AvgHeroBulletsHitCritPerMatch => "avg(max_hero_bullets_hit_crit)",
             Self::HeroBulletsHitCrit => "sum(max_hero_bullets_hit_crit)",
-        }
+        };
+        clause.to_owned()
     }
 
     /// Whether the sort's aggregate ignores duplicate `ReplacingMergeTree` rows, letting
@@ -209,63 +231,67 @@ impl ScoreboardQuerySortBy {
         matches!(self, Self::Matches)
     }
 
-    /// Column from `match_player` that must be carried through the per-(`account_id`, `match_id`)
-    /// dedup subquery. `None` means the sort only needs `match_id`, which is always projected.
-    /// Used by `player_scoreboard` to deduplicate `ReplacingMergeTree` rows without `FINAL`
-    /// while still getting correct `sum` / `countIf` aggregates.
-    pub(super) fn inner_column(self) -> Option<&'static str> {
+    /// Columns from `match_player` that must be carried through the per-(`account_id`,
+    /// `match_id`) dedup subquery. Empty means the sort only needs `match_id`, which is always
+    /// projected. Used by `player_scoreboard` to deduplicate `ReplacingMergeTree` rows without
+    /// `FINAL` while still getting correct `sum` / `countIf` aggregates.
+    pub(super) fn inner_columns(self) -> &'static [&'static str] {
         match self {
-            Self::Matches => None,
-            Self::Wins | Self::Losses | Self::Winrate => Some("won"),
-            Self::MaxKillsPerMatch | Self::AvgKillsPerMatch | Self::Kills => Some("kills"),
-            Self::MaxDeathsPerMatch | Self::AvgDeathsPerMatch | Self::Deaths => Some("deaths"),
+            Self::Matches => &[],
+            Self::Rank => &[
+                "player_rank_final_flat_progress",
+                "player_rank_initial_display_rank",
+            ],
+            Self::Wins | Self::Losses | Self::Winrate => &["won"],
+            Self::MaxKillsPerMatch | Self::AvgKillsPerMatch | Self::Kills => &["kills"],
+            Self::MaxDeathsPerMatch | Self::AvgDeathsPerMatch | Self::Deaths => &["deaths"],
             Self::MaxDamageTakenPerMatch | Self::AvgDamageTakenPerMatch | Self::DamageTaken => {
-                Some("max_player_damage_taken")
+                &["max_player_damage_taken"]
             }
-            Self::MaxAssistsPerMatch | Self::AvgAssistsPerMatch | Self::Assists => Some("assists"),
+            Self::MaxAssistsPerMatch | Self::AvgAssistsPerMatch | Self::Assists => &["assists"],
             Self::MaxNetWorthPerMatch | Self::AvgNetWorthPerMatch | Self::NetWorth => {
-                Some("net_worth")
+                &["net_worth"]
             }
             Self::MaxLastHitsPerMatch | Self::AvgLastHitsPerMatch | Self::LastHits => {
-                Some("last_hits")
+                &["last_hits"]
             }
-            Self::MaxDeniesPerMatch | Self::AvgDeniesPerMatch | Self::Denies => Some("denies"),
+            Self::MaxDeniesPerMatch | Self::AvgDeniesPerMatch | Self::Denies => &["denies"],
             Self::MaxPlayerLevelPerMatch | Self::AvgPlayerLevelPerMatch | Self::PlayerLevel => {
-                Some("player_level")
+                &["player_level"]
             }
             Self::MaxCreepKillsPerMatch | Self::AvgCreepKillsPerMatch | Self::CreepKills => {
-                Some("max_creep_kills")
+                &["max_creep_kills"]
             }
             Self::MaxNeutralKillsPerMatch | Self::AvgNeutralKillsPerMatch | Self::NeutralKills => {
-                Some("max_neutral_kills")
+                &["max_neutral_kills"]
             }
             Self::MaxCreepDamagePerMatch | Self::AvgCreepDamagePerMatch | Self::CreepDamage => {
-                Some("max_creep_damage")
+                &["max_creep_damage"]
             }
             Self::MaxPlayerDamagePerMatch | Self::AvgPlayerDamagePerMatch | Self::PlayerDamage => {
-                Some("max_player_damage")
+                &["max_player_damage"]
             }
             Self::MaxNeutralDamagePerMatch
             | Self::AvgNeutralDamagePerMatch
-            | Self::NeutralDamage => Some("max_neutral_damage"),
+            | Self::NeutralDamage => &["max_neutral_damage"],
             Self::MaxBossDamagePerMatch | Self::AvgBossDamagePerMatch | Self::BossDamage => {
-                Some("max_boss_damage")
+                &["max_boss_damage"]
             }
             Self::MaxMaxHealthPerMatch | Self::AvgMaxHealthPerMatch | Self::MaxHealth => {
-                Some("max_max_health")
+                &["max_max_health"]
             }
             Self::MaxShotsHitPerMatch | Self::AvgShotsHitPerMatch | Self::ShotsHit => {
-                Some("max_shots_hit")
+                &["max_shots_hit"]
             }
             Self::MaxShotsMissedPerMatch | Self::AvgShotsMissedPerMatch | Self::ShotsMissed => {
-                Some("max_shots_missed")
+                &["max_shots_missed"]
             }
             Self::MaxHeroBulletsHitPerMatch
             | Self::AvgHeroBulletsHitPerMatch
-            | Self::HeroBulletsHit => Some("max_hero_bullets_hit"),
+            | Self::HeroBulletsHit => &["max_hero_bullets_hit"],
             Self::MaxHeroBulletsHitCritPerMatch
             | Self::AvgHeroBulletsHitCritPerMatch
-            | Self::HeroBulletsHitCrit => Some("max_hero_bullets_hit_crit"),
+            | Self::HeroBulletsHitCrit => &["max_hero_bullets_hit_crit"],
         }
     }
 }

--- a/website/src/components/player-scoreboard/ScoreboardTable.tsx
+++ b/website/src/components/player-scoreboard/ScoreboardTable.tsx
@@ -46,8 +46,6 @@ export function ScoreboardTable({
 
   const { profiles, isLoading: isLoadingProfiles } = useSteamProfiles(steamAccountIds);
 
-  // `sort_by=rank` reports the badge the player ended their latest ranked match on, so show it as
-  // a badge rather than as the bare number.
   const isRankSort = sortBy === "rank";
   const { data: ranks } = useQuery({ ...ranksQueryOptions, enabled: isRankSort });
   const badgeMap = useMemo(() => extractBadgeMap(ranks ?? []), [ranks]);

--- a/website/src/components/player-scoreboard/ScoreboardTable.tsx
+++ b/website/src/components/player-scoreboard/ScoreboardTable.tsx
@@ -1,12 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
 import type { PlayerEntry } from "deadlock_api_client";
 import Fuse from "fuse.js";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { useMemo, useState } from "react";
 
+import { BadgeImage } from "~/components/BadgeImage";
 import { PaginationControls } from "~/components/PaginationControls";
 import { Skeleton } from "~/components/ui/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
 import { useSteamProfiles } from "~/hooks/useSteamProfiles";
+import { extractBadgeMap } from "~/lib/leaderboard";
+import { ranksQueryOptions } from "~/queries/ranks-query";
 
 import { formatStatValue } from "./sort-options";
 import { SortBySelector } from "./SortBySelector";
@@ -41,6 +45,24 @@ export function ScoreboardTable({
   );
 
   const { profiles, isLoading: isLoadingProfiles } = useSteamProfiles(steamAccountIds);
+
+  // `sort_by=rank` reports the badge the player ended their latest ranked match on, so show it as
+  // a badge rather than as the bare number.
+  const isRankSort = sortBy === "rank";
+  const { data: ranks } = useQuery({ ...ranksQueryOptions, enabled: isRankSort });
+  const badgeMap = useMemo(() => extractBadgeMap(ranks ?? []), [ranks]);
+
+  const renderValue = (value: number) => {
+    if (!isRankSort) return formatStatValue(value, sortBy);
+    const badge = badgeMap.get(value);
+    if (!badge) return <span className="text-muted-foreground">Unranked</span>;
+    return (
+      <div className="flex items-center justify-end gap-1.5">
+        <BadgeImage badge={value} ranks={ranks ?? []} className="size-6" />
+        <span>{`${badge.name} ${badge.subtier}`}</span>
+      </div>
+    );
+  };
 
   const enrichedEntries = useMemo(
     () =>
@@ -165,7 +187,7 @@ export function ScoreboardTable({
                   </div>
                 </TableCell>
                 {sortBy !== "matches" && <TableCell className="text-right">{entry.matches.toLocaleString()}</TableCell>}
-                <TableCell className="text-right">{formatStatValue(entry.value, sortBy)}</TableCell>
+                <TableCell className="text-right">{renderValue(entry.value)}</TableCell>
               </TableRow>
             );
           })}

--- a/website/src/components/player-scoreboard/sort-options.ts
+++ b/website/src/components/player-scoreboard/sort-options.ts
@@ -36,6 +36,7 @@ const ALL_VARIANTS: SortVariant[] = ["avg", "max", "total"];
 
 export const SORT_CATEGORIES: SortCategory[] = [
   { label: "Matches", key: "matches" },
+  { label: "Rank", key: "rank" },
   { label: "Wins", key: "wins" },
   { label: "Losses", key: "losses" },
   { label: "Winrate", key: "winrate" },


### PR DESCRIPTION
## Description

Adds `sort_by=rank` to `GET /v1/analytics/scoreboards/players`.

The value is the badge Valve reported at the **end of the player's latest ranked match inside the filtered range** — the rank they entered that match with plus the progress it awarded, the same definition `/v1/players/{account_id}/rank` and `/v1/analytics/badge-distribution` use.

Combined with `hero_id` and a time range this answers "who are the highest ranked players on this hero right now" without hand-picking a badge range, which the `min/max_average_badge` filters could not express (they filter on the match's average badge, not the player's own rank).

```
/v1/analytics/scoreboards/players?sort_by=rank&hero_id=<celeste>&min_unix_timestamp=<2 weeks ago>&limit=100
```

Implementation notes:

- The aggregate is `argMaxIf(player_rank_final_flat_progress, match_id, ifNull(player_rank_initial_display_rank, 0) > 0)` fed through the shared `badge_from_flat_progress_sql` helper. Only ranked matches carry a rank and `initial_display_rank` stays `0` for the whole of placement, so those rows must not contribute a badge — hence the `-If` guard over a plain `argMax`.
- Players with no ranked match in range get a `value` of `0` (unranked) instead of a `NULL` the non-nullable `value` column cannot hold.
- `inner_column` became `inner_columns` (a slice): the badge needs both rank columns to survive the per-(`account_id`, `match_id`) dedup subquery, where a single column was enough for every existing sort. The `FINAL` and `dedup_free` paths are unchanged.
- The hero scoreboard shares the sort enum but a rank belongs to a player, not a hero, so it rejects `sort_by=rank` with a `400`.
- Website: the player scoreboard sort selector gets a "Rank" option and renders the value as a rank badge + name rather than the bare badge number.

## Related Issue

No tracked issue — requested on Discord (filtering the scoreboard to high-rank players without setting a badge manually).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- [x] Unit tests

Three new tests in `player_scoreboard.rs` cover the rank sort on both query paths: SQL validity via the ClickHouse grammar (`assert_valid_sql`), that the dedup subquery carries both rank columns through, and the `0` fallback for players with no ranked match in range. The existing scoreboard proptests still pass.

`cargo clippy --all-targets --locked -- -D warnings` and `cargo fmt` are clean. Full `cargo test --lib`: 335 pass, the only 2 failures are the Steam patch-feed tests, which need network access to `forums.playdeadlock.com` / `store.steampowered.com` and are unrelated to this change.

Not run: the website `pnpm lint` / `typecheck` / `build`, because `pnpm install` cannot fetch the `deadlock_api_client` dependency from `codeload.github.com` in this environment. The changed `.tsx`/`.ts` files parse clean, but the website side is worth a look before merge.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (endpoint descriptions in the OpenAPI spec)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

`sort_by=rank` is a new value on the shared scoreboard sort enum, so the generated OpenAPI clients need a regen before the website can drop its `as PlayerScoreboardSortByEnum` cast.

Ties are common at the top of the ladder (many players sit at the same badge), and the order within a tie is arbitrary — worth keeping in mind if this ever backs a "top N%" cutoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hEYBA8fSgnVq683Gexfw5

---
_Generated by [Claude Code](https://claude.ai/code/session_018hEYBA8fSgnVq683Gexfw5)_