### PR TITLE
feat(website): filter hero combos by included/excluded heroes

### DIFF
--- a/website/src/components/heroes-page/HeroCombStatsTable.tsx
+++ b/website/src/components/heroes-page/HeroCombStatsTable.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { parseAsInteger, useQueryState } from "nuqs";
+import { parseAsArrayOf, parseAsInteger, useQueryState } from "nuqs";
 import { useId, useMemo } from "react";
 
 import { HeroImage } from "~/components/HeroImage";
@@ -7,6 +7,7 @@ import { HeroName } from "~/components/HeroName";
 import { LoadingLogo } from "~/components/LoadingLogo";
 import { ProgressBarWithLabel } from "~/components/primitives/ProgressBar";
 import type { GameMode } from "~/components/selectors/GameModeSelector";
+import { HeroSelectorMultiple } from "~/components/selectors/HeroSelector";
 import type { MatchMode } from "~/components/selectors/MatchModeSelector";
 import { Slider } from "~/components/ui/slider";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
@@ -53,6 +54,14 @@ export function HeroCombStatsTable({
   const [combSizeDraft, setCombSizeDraft] = useDraftValue(combSizeFilter);
   const [combsToShow, setCombsToShow] = useQueryState("combs_to_show", parseAsInteger.withDefault(limit ?? 50));
   const [combsToShowDraft, setCombsToShowDraft] = useDraftValue(combsToShow);
+  const [includeHeroIds, setIncludeHeroIds] = useQueryState(
+    "comb_include_heroes",
+    parseAsArrayOf(parseAsInteger).withDefault([]),
+  );
+  const [excludeHeroIds, setExcludeHeroIds] = useQueryState(
+    "comb_exclude_heroes",
+    parseAsArrayOf(parseAsInteger).withDefault([]),
+  );
 
   const { minUnixTimestamp, maxUnixTimestamp } = useNormalizedTimeRange(minDate, maxDate);
   const { minUnixTimestamp: prevMinTimestamp, maxUnixTimestamp: prevMaxTimestamp } = useNormalizedTimeRange(
@@ -61,8 +70,22 @@ export function HeroCombStatsTable({
   );
   const hasPreviousInterval = prevMinDate != null && prevMaxDate != null;
 
+  const handleIncludeHeroesChange = (heroIds: number[]) => {
+    setIncludeHeroIds(heroIds);
+    setExcludeHeroIds((prev) => prev.filter((heroId) => !heroIds.includes(heroId)));
+  };
+  const handleExcludeHeroesChange = (heroIds: number[]) => {
+    setExcludeHeroIds(heroIds);
+    setIncludeHeroIds((prev) => prev.filter((heroId) => !heroIds.includes(heroId)));
+  };
+
+  const includeHeroIdsParam = includeHeroIds.length > 0 ? includeHeroIds : undefined;
+  const excludeHeroIdsParam = excludeHeroIds.length > 0 ? excludeHeroIds : undefined;
+
   const combStatsQuery = {
     combSize: combSizeFilter,
+    includeHeroIds: includeHeroIdsParam,
+    excludeHeroIds: excludeHeroIdsParam,
     minMatches: minHeroMatches ?? 0,
     minAverageBadge: minRankId,
     maxAverageBadge: maxRankId,
@@ -82,6 +105,8 @@ export function HeroCombStatsTable({
 
   const prevCombStatsQuery = {
     combSize: combSizeFilter,
+    includeHeroIds: includeHeroIdsParam,
+    excludeHeroIds: excludeHeroIdsParam,
     minMatches: minHeroMatches ?? 0,
     minAverageBadge: minRankId,
     maxAverageBadge: maxRankId,
@@ -123,8 +148,11 @@ export function HeroCombStatsTable({
     () =>
       [...(heroData || [])]
         .filter((row) => new Set(row.hero_ids).size === combSizeFilter)
+        // The API filters whole teams, so a combination may still be missing an included hero.
+        .filter((row) => includeHeroIds.every((heroId) => row.hero_ids.includes(heroId)))
+        .filter((row) => !excludeHeroIds.some((heroId) => row.hero_ids.includes(heroId)))
         .sort((a, b) => b?.wins / b?.matches - a?.wins / a?.matches),
-    [heroData, combSizeFilter],
+    [heroData, combSizeFilter, includeHeroIds, excludeHeroIds],
   );
   const minWinrate = useMemo(
     () => sortedData[sortedData.length - 1]?.wins / sortedData[sortedData.length - 1]?.matches || 0,
@@ -181,7 +209,31 @@ export function HeroCombStatsTable({
             <span className="ml-2">{combsToShowDraft}</span>
           </div>
         </div>
+
+        <div className="flex flex-col gap-1.5">
+          <span className="text-sm text-nowrap text-muted-foreground">Include Heroes</span>
+          <HeroSelectorMultiple
+            selectedHeroes={includeHeroIds}
+            onHeroesSelected={handleIncludeHeroesChange}
+            label="Any Hero"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <span className="text-sm text-nowrap text-muted-foreground">Exclude Heroes</span>
+          <HeroSelectorMultiple
+            selectedHeroes={excludeHeroIds}
+            onHeroesSelected={handleExcludeHeroesChange}
+            label="No Hero"
+          />
+        </div>
       </div>
+      {includeHeroIds.length > combSizeFilter && (
+        <p className="mx-auto text-sm text-muted-foreground">
+          No combination can contain all {includeHeroIds.length} included heroes at a combination size of{" "}
+          {combSizeFilter}. Increase the combination size to see results.
+        </p>
+      )}
       {isLoading ? (
         <div className="flex h-full w-full items-center justify-center py-16">
           <LoadingLogo />

--- a/website/src/components/selectors/HeroSelector.tsx
+++ b/website/src/components/selectors/HeroSelector.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from "react";
 import { FilterPill } from "~/components/FilterPill";
 import { HeroImage } from "~/components/HeroImage";
 import { HeroName } from "~/components/HeroName";
+import { FilteredSelectPopover } from "~/components/selectors/FilteredSelectPopover";
 import { Input } from "~/components/ui/input";
 import { heroesQueryOptions } from "~/queries/asset-queries";
 
@@ -95,5 +96,43 @@ export function HeroSelector({
         ))}
       </div>
     </FilterPill>
+  );
+}
+
+export function HeroSelectorMultiple({
+  onHeroesSelected,
+  selectedHeroes,
+  label,
+}: {
+  onHeroesSelected: (selectedHeroes: number[]) => void;
+  selectedHeroes: number[];
+  label?: string;
+}) {
+  const { sortedHeroes, isLoading } = useHeroes();
+
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <FilteredSelectPopover
+      items={sortedHeroes}
+      selectedIds={selectedHeroes}
+      onSelectedIdsChange={onHeroesSelected}
+      getId={(hero: Hero) => hero.id}
+      emptyLabel={label ?? "Select Heroes..."}
+      renderChip={(heroId) => (
+        <>
+          <HeroImage heroId={heroId} className="size-4 shrink-0 object-contain" />
+          <HeroName heroId={heroId} className="truncate text-xs" />
+        </>
+      )}
+      renderRow={(hero: Hero) => (
+        <>
+          <HeroImage heroId={hero.id} className="size-5 shrink-0 object-contain" />
+          <HeroName heroId={hero.id} className="truncate text-sm" />
+        </>
+      )}
+    />
   );
 }


### PR DESCRIPTION
## Description

Adds **Include Heroes** and **Exclude Heroes** multi-select filters to the Combos tab of the heroes page, next to the existing combination-size / combinations-to-show controls.

- Both selections are forwarded to `/v1/analytics/hero-comb-stats` as `include_hero_ids` / `exclude_hero_ids` (the endpoint already supported them) for the current and the previous-interval query, so win-rate/pick-rate deltas stay comparable.
- The endpoint filters whole teams rather than combinations, so a query for "teams containing Abrams" also returns combos without Abrams. Those rows are dropped client side, which makes the include filter read as "combos containing these heroes".
- Both lists live in the URL (`comb_include_heroes`, `comb_exclude_heroes`), so a filtered view can be shared and survives a reload.
- Picking a hero on one side removes it from the other, and a hint appears when more heroes are included than fit into the current combination size.
- `HeroSelectorMultiple` is added next to the existing `HeroSelector`, mirroring `ItemSelectorMultiple` on top of `FilteredSelectPopover`.

## Related Issue

n/a

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## How Has This Been Tested?

- [x] Manual testing

The live API is not reachable from the environment this was developed in, so the page was driven in a headless browser against a local stub of `hero-comb-stats` that reproduces the endpoint's team-level filtering. Verified:

- selecting an include hero sends `include_hero_ids` and narrows the table to combos containing that hero;
- selecting an exclude hero sends `exclude_hero_ids` and removes those combos;
- selecting a hero on one side clears it from the other;
- the hint shows when the include count exceeds the combination size;
- filters round-trip through the URL on reload.

`pnpm typecheck`, `pnpm lint` (no new warnings) and `pnpm build` all pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Screenshots (if applicable)

Filter row with `Include Heroes: Abrams` and `Exclude Heroes: Wraith` applied (stubbed data):

| Control | Behaviour |
| --- | --- |
| Include Heroes | table shows only combos containing every selected hero |
| Exclude Heroes | matches where a selected hero was on the team are dropped by the API |

## Additional Notes

No API changes were needed — `include_hero_ids` / `exclude_hero_ids` already exist on the endpoint.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJDTw4tKXDEHByej633Xc2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-select hero filters for including or excluding heroes in combination statistics.
  * Filter selections are preserved in the URL and applied to current and previous statistics.
  * Added a notice when more heroes are selected than the chosen combination size.
  * Included visual chips and labels to make selected heroes easier to manage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->