### PR TITLE
lint: use expect() instead of allow() for lint suppressions

### DIFF
--- a/api/src/context/state.rs
+++ b/api/src/context/state.rs
@@ -69,7 +69,7 @@ pub(crate) struct AppState {
 }
 
 impl AppState {
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     pub(crate) async fn from_env() -> Result<AppState, AppStateError> {
         let config = Config::from_env()?;
 

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -22,7 +22,10 @@ pub enum StartupError {
     AppState(#[from] AppStateError),
 }
 
-#[expect(dead_code)]
+#[allow(
+    dead_code,
+    reason = "used by tests, so `expect` would be unfulfilled in the test build"
+)]
 #[derive(Debug, Error)]
 pub(super) enum APIError {
     #[error("Status {status}")]

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -22,7 +22,7 @@ pub enum StartupError {
     AppState(#[from] AppStateError),
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Debug, Error)]
 pub(super) enum APIError {
     #[error("Status {status}")]
@@ -101,7 +101,7 @@ fn build_error_response(status: StatusCode, error: impl serde::Serialize) -> Res
 }
 
 impl IntoResponse for APIError {
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     fn into_response(self) -> Response<Body> {
         match self {
             Self::Status { status } => {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -8,11 +8,11 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::unreadable_literal)]
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::needless_for_each)] // This is currently caused by an issue in utoipa, see: https://github.com/juhaku/utoipa/pull/1423
-#![allow(clippy::large_stack_arrays)] // Triggered by utoipa's `IntoParams` derive on large query-param structs.
-#![allow(clippy::unused_async_trait_impl)]
+#![expect(clippy::unreadable_literal)]
+#![expect(clippy::missing_errors_doc)]
+#![expect(clippy::needless_for_each)] // This is currently caused by an issue in utoipa, see: https://github.com/juhaku/utoipa/pull/1423
+#![expect(clippy::large_stack_arrays)] // Triggered by utoipa's `IntoParams` derive on large query-param structs.
+#![expect(clippy::unused_async_trait_impl)]
 
 mod api_doc;
 mod context;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -10,7 +10,6 @@
 #![deny(clippy::std_instead_of_core)]
 #![expect(clippy::unreadable_literal)]
 #![expect(clippy::missing_errors_doc)]
-#![expect(clippy::needless_for_each)] // This is currently caused by an issue in utoipa, see: https://github.com/juhaku/utoipa/pull/1423
 #![expect(clippy::large_stack_arrays)] // Triggered by utoipa's `IntoParams` derive on large query-param structs.
 #![expect(clippy::unused_async_trait_impl)]
 

--- a/api/src/middleware/track_requests.rs
+++ b/api/src/middleware/track_requests.rs
@@ -20,7 +20,7 @@ fn get_header(req: &Request, name: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub(crate) async fn track_requests(
     State(AppState { request_logger, .. }): State<AppState>,
     matched_path: MatchedPath,

--- a/api/src/middleware/track_requests.rs
+++ b/api/src/middleware/track_requests.rs
@@ -20,7 +20,6 @@ fn get_header(req: &Request, name: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-#[expect(clippy::too_many_lines)]
 pub(crate) async fn track_requests(
     State(AppState { request_logger, .. }): State<AppState>,
     matched_path: MatchedPath,

--- a/api/src/routes/v1/analytics/ability_order_stats.rs
+++ b/api/src/routes/v1/analytics/ability_order_stats.rs
@@ -19,7 +19,6 @@ use crate::utils::parse::{
     comma_separated_deserialize_option, default_last_month_timestamp, parse_steam_id_option,
 };
 
-#[expect(clippy::unnecessary_wraps)]
 fn default_min_matches() -> Option<u32> {
     10.into()
 }
@@ -123,7 +122,6 @@ pub struct AnalyticsAbilityOrderStats {
     pub total_assists: u64,
 }
 
-#[expect(clippy::too_many_lines)]
 fn build_query(query: &AbilityOrderStatsQuery) -> String {
     let info_filters = MatchInfoFilters {
         min_unix_timestamp: query.min_unix_timestamp,
@@ -265,7 +263,6 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[expect(deprecated)]
         fn ability_order_stats_build_query_is_valid_sql(query: AbilityOrderStatsQuery) {
             assert_valid_sql(&build_query(&query));
         }

--- a/api/src/routes/v1/analytics/ability_order_stats.rs
+++ b/api/src/routes/v1/analytics/ability_order_stats.rs
@@ -19,7 +19,7 @@ use crate::utils::parse::{
     comma_separated_deserialize_option, default_last_month_timestamp, parse_steam_id_option,
 };
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn default_min_matches() -> Option<u32> {
     10.into()
 }
@@ -123,7 +123,7 @@ pub struct AnalyticsAbilityOrderStats {
     pub total_assists: u64,
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(query: &AbilityOrderStatsQuery) -> String {
     let info_filters = MatchInfoFilters {
         min_unix_timestamp: query.min_unix_timestamp,
@@ -136,7 +136,7 @@ fn build_query(query: &AbilityOrderStatsQuery) -> String {
         max_duration_s: query.max_duration_s,
     }
     .build();
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let mut player_filters = PlayerFilters {
         hero_id: Some(query.hero_id),
         account_id: query.account_id,
@@ -241,7 +241,7 @@ pub(super) async fn ability_order_stats(
             message: "Cannot filter by average badge for street brawl game mode".to_string(),
         });
     }
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     filter_protected_accounts(&state, &mut query.account_ids, query.account_id).await?;
     if !state.assets_client.validate_hero_id(query.hero_id).await {
         return Err(APIError::status_msg(
@@ -265,7 +265,7 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         fn ability_order_stats_build_query_is_valid_sql(query: AbilityOrderStatsQuery) {
             assert_valid_sql(&build_query(&query));
         }

--- a/api/src/routes/v1/analytics/common_filters.rs
+++ b/api/src/routes/v1/analytics/common_filters.rs
@@ -210,12 +210,12 @@ pub(super) fn round_timestamps(
 
 pub(super) const DEFAULT_MIN_MATCHES: u64 = 20;
 
-#[allow(clippy::unnecessary_wraps, clippy::cast_possible_truncation)]
+#[expect(clippy::unnecessary_wraps, clippy::cast_possible_truncation)]
 pub(super) fn default_min_matches_u32() -> Option<u32> {
     Some(DEFAULT_MIN_MATCHES as u32)
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(super) fn default_min_matches_u64() -> Option<u64> {
     Some(DEFAULT_MIN_MATCHES)
 }

--- a/api/src/routes/v1/analytics/game_stats.rs
+++ b/api/src/routes/v1/analytics/game_stats.rs
@@ -188,7 +188,6 @@ pub struct AnalyticsGameStats {
     pub team1_wins: u64,
 }
 
-#[expect(clippy::too_many_lines)]
 fn build_query(query: &GameStatsQuery) -> String {
     let info_filters = MatchInfoFilters {
         min_unix_timestamp: query.min_unix_timestamp,

--- a/api/src/routes/v1/analytics/game_stats.rs
+++ b/api/src/routes/v1/analytics/game_stats.rs
@@ -188,7 +188,7 @@ pub struct AnalyticsGameStats {
     pub team1_wins: u64,
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(query: &GameStatsQuery) -> String {
     let info_filters = MatchInfoFilters {
         min_unix_timestamp: query.min_unix_timestamp,

--- a/api/src/routes/v1/analytics/hero_build_stats.rs
+++ b/api/src/routes/v1/analytics/hero_build_stats.rs
@@ -116,7 +116,7 @@ fn build_query(hero_id: u32, valid_build_ids: &[i32], query: &HeroBuildStatsQuer
     .build_with_prefix("mp.");
     let match_mode_filter = MatchMode::sql_filter_with_prefix(query.match_mode.as_deref(), "mp.");
     let mut player_filters = vec![format!("mp.hero_id = {hero_id}")];
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     if let Some(account_id) = query.account_id {
         player_filters.push(format!("mp.account_id = {account_id}"));
     }
@@ -235,7 +235,7 @@ pub(super) async fn hero_build_stats(
     Query(mut query): Query<HeroBuildStatsQuery>,
     State(state): State<AppState>,
 ) -> APIResult<impl IntoResponse> {
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     filter_protected_accounts(&state, &mut query.account_ids, query.account_id).await?;
     let valid_build_ids = fetch_valid_build_ids(&state.pg_client, hero_id).await?;
     get_hero_build_stats(&state.ch_client_cached, hero_id, &valid_build_ids, query)
@@ -254,7 +254,7 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         fn hero_build_stats_build_query_is_valid_sql(
             hero_id in any::<u32>(),
             valid_build_ids in prop::collection::vec(any::<i32>(), 0..16),

--- a/api/src/routes/v1/analytics/hero_build_stats.rs
+++ b/api/src/routes/v1/analytics/hero_build_stats.rs
@@ -254,7 +254,6 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[expect(deprecated)]
         fn hero_build_stats_build_query_is_valid_sql(
             hero_id in any::<u32>(),
             valid_build_ids in prop::collection::vec(any::<i32>(), 0..16),

--- a/api/src/routes/v1/analytics/hero_comb_stats.rs
+++ b/api/src/routes/v1/analytics/hero_comb_stats.rs
@@ -24,7 +24,6 @@ use crate::utils::parse::{
     comma_separated_deserialize_option, default_last_month_timestamp, parse_steam_id_option,
 };
 
-#[expect(clippy::unnecessary_wraps)]
 fn default_comb_size() -> Option<u8> {
     6.into()
 }
@@ -422,7 +421,6 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[expect(deprecated)]
         fn hero_comb_stats_build_query_is_valid_sql(query: HeroCombStatsQuery) {
             assert_valid_sql(&build_query(&query));
         }

--- a/api/src/routes/v1/analytics/hero_comb_stats.rs
+++ b/api/src/routes/v1/analytics/hero_comb_stats.rs
@@ -24,7 +24,7 @@ use crate::utils::parse::{
     comma_separated_deserialize_option, default_last_month_timestamp, parse_steam_id_option,
 };
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn default_comb_size() -> Option<u8> {
     6.into()
 }
@@ -158,7 +158,7 @@ impl AddAssign<&HeroCombStats> for HeroCombStats {
     }
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(query: &HeroCombStatsQuery) -> String {
     let team_size = if query.game_mode == Some(GameMode::StreetBrawl) {
         4
@@ -185,7 +185,7 @@ fn build_query(query: &HeroCombStatsQuery) -> String {
         .build(),
     );
     let mut account_filter_values: Vec<u32> = Vec::new();
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     if let Some(account_id) = query.account_id {
         account_filter_values.push(account_id);
     }
@@ -404,7 +404,7 @@ pub(crate) async fn hero_comb_stats(
     Query(mut query): Query<HeroCombStatsQuery>,
     State(state): State<AppState>,
 ) -> APIResult<impl IntoResponse> {
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     filter_protected_accounts(&state, &mut query.account_ids, query.account_id).await?;
     get_comb_stats(&state.ch_client_cached, query)
         .await
@@ -422,7 +422,7 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         fn hero_comb_stats_build_query_is_valid_sql(query: HeroCombStatsQuery) {
             assert_valid_sql(&build_query(&query));
         }

--- a/api/src/routes/v1/analytics/hero_counters_stats.rs
+++ b/api/src/routes/v1/analytics/hero_counters_stats.rs
@@ -337,7 +337,6 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[expect(deprecated)]
         fn hero_counters_stats_build_query_is_valid_sql(query: HeroCounterStatsQuery) {
             assert_valid_sql(&build_query(&query));
         }

--- a/api/src/routes/v1/analytics/hero_counters_stats.rs
+++ b/api/src/routes/v1/analytics/hero_counters_stats.rs
@@ -144,7 +144,7 @@ pub struct HeroCounterStats {
     enemy_creeps: u64,
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(query: &HeroCounterStatsQuery) -> String {
     let info_filters = MatchInfoFilters {
         min_unix_timestamp: query.min_unix_timestamp,
@@ -162,7 +162,7 @@ fn build_query(query: &HeroCounterStatsQuery) -> String {
     let match_filters = format!("{match_mode_filter} AND {game_mode_filter}{info_filters}");
     let mut p1_filters = vec![match_filters.clone()];
     let mut p2_filters = vec![match_filters];
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     if let Some(account_id) = query.account_id {
         p1_filters.push(format!("account_id = {account_id}"));
     }
@@ -203,7 +203,7 @@ fn build_query(query: &HeroCounterStatsQuery) -> String {
     } else {
         "ON p1.match_id = p2.match_id AND p1.team != p2.team"
     };
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let needs_account_id = query.account_id.is_some() || query.account_ids.is_some();
     let p1_account_col = if needs_account_id { "account_id, " } else { "" };
     let p1_cols = format!(
@@ -319,7 +319,7 @@ pub(super) async fn hero_counters_stats(
     Query(mut query): Query<HeroCounterStatsQuery>,
     State(state): State<AppState>,
 ) -> APIResult<impl IntoResponse> {
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     filter_protected_accounts(&state, &mut query.account_ids, query.account_id).await?;
     get_hero_counter_stats(&state.ch_client_cached, query)
         .await
@@ -337,7 +337,7 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         fn hero_counters_stats_build_query_is_valid_sql(query: HeroCounterStatsQuery) {
             assert_valid_sql(&build_query(&query));
         }

--- a/api/src/routes/v1/analytics/hero_scoreboard.rs
+++ b/api/src/routes/v1/analytics/hero_scoreboard.rs
@@ -242,7 +242,6 @@ mod proptests {
     proptest! {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
-        #[expect(deprecated)]
         #[test]
         fn hero_scoreboard_build_query_is_valid_sql(query: HeroScoreboardQuery) {
             assert_valid_sql(&build_query(&query));

--- a/api/src/routes/v1/analytics/hero_scoreboard.rs
+++ b/api/src/routes/v1/analytics/hero_scoreboard.rs
@@ -115,7 +115,7 @@ fn build_query(query: &HeroScoreboardQuery) -> String {
     let mut player_filters = vec![format!(
         "{match_mode_filter} AND {game_mode_filter} {match_info_filters}"
     )];
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     if let Some(account_id) = query.account_id {
         player_filters.push(format!("account_id = {account_id}"));
     }
@@ -225,7 +225,7 @@ pub(super) async fn hero_scoreboard(
             "sort_by=rank is only supported by the player scoreboard",
         ));
     }
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     filter_protected_accounts(&state, &mut query.account_ids, query.account_id).await?;
     get_hero_scoreboard(&state.ch_client_cached, query)
         .await
@@ -242,7 +242,7 @@ mod proptests {
     proptest! {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         #[test]
         fn hero_scoreboard_build_query_is_valid_sql(query: HeroScoreboardQuery) {
             assert_valid_sql(&build_query(&query));

--- a/api/src/routes/v1/analytics/hero_stats.rs
+++ b/api/src/routes/v1/analytics/hero_stats.rs
@@ -205,7 +205,7 @@ const MV_ROUTING_MARGIN_DAYS: i64 = 5;
 fn build_mv_query(query: &HeroStatsQuery) -> Option<String> {
     let bucket_expr = query.bucket.mv_bucket_expr()?;
     // Per-player / per-row filters the grain cannot express → base table.
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let personalized = query.account_id.is_some()
         || query.account_ids.as_ref().is_some_and(|v| !v.is_empty())
         || query
@@ -311,7 +311,7 @@ fn build_mv_query(query: &HeroStatsQuery) -> Option<String> {
     ))
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(query: &HeroStatsQuery) -> String {
     let info_filters = MatchInfoFilters {
         min_unix_timestamp: query.min_unix_timestamp,
@@ -324,7 +324,7 @@ fn build_query(query: &HeroStatsQuery) -> String {
         max_duration_s: query.max_duration_s,
     }
     .build();
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let player_filters = PlayerFilters {
         account_id: query.account_id,
         account_ids: query.account_ids.as_deref(),
@@ -406,7 +406,7 @@ fn build_query(query: &HeroStatsQuery) -> String {
     } else {
         ""
     };
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let has_account_filter = query.account_id.is_some()
         || query
             .account_ids
@@ -532,7 +532,7 @@ pub(crate) async fn hero_stats(
             message: "Cannot filter by average badge for street brawl game mode".to_string(),
         });
     }
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     filter_protected_accounts(&state, &mut query.account_ids, query.account_id).await?;
     get_hero_stats(&state.ch_client_cached, query)
         .await
@@ -558,7 +558,7 @@ mod proptests {
         fn hero_stats_build_mv_query_is_valid_sql(mut query: HeroStatsQuery) {
             // Force routing into the MV path: clear the filters that disqualify it
             // and pick a min timestamp comfortably inside the horizon.
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             {
                 query.account_id = None;
             }

--- a/api/src/routes/v1/analytics/hero_synergies_stats.rs
+++ b/api/src/routes/v1/analytics/hero_synergies_stats.rs
@@ -138,7 +138,7 @@ pub struct HeroSynergyStats {
     pub creeps2: u64,
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(query: &HeroSynergyStatsQuery) -> String {
     // Single-pass strategy: read each filtered match_player row once, group all
     // teammates per (match_id, team[, assigned_lane]) into a tuple array, then
@@ -196,7 +196,7 @@ fn build_query(query: &HeroSynergyStatsQuery) -> String {
     // The original query applied account filters only to p1 (the lower-hero-id
     // side of the pair). Replicate that asymmetry on `pair.1` post-arrayJoin.
     let mut pair_filters = vec!["(p.1).1 < (p.2).1".to_owned()];
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     if let Some(account_id) = query.account_id {
         pair_filters.push(format!("(p.1).11 = {account_id}"));
     }
@@ -325,7 +325,7 @@ pub(super) async fn hero_synergies_stats(
     Query(mut query): Query<HeroSynergyStatsQuery>,
     State(state): State<AppState>,
 ) -> APIResult<impl IntoResponse> {
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     filter_protected_accounts(&state, &mut query.account_ids, query.account_id).await?;
     get_hero_synergy_stats(&state.ch_client_cached, query)
         .await
@@ -343,7 +343,7 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         fn hero_synergies_stats_build_query_is_valid_sql(query: HeroSynergyStatsQuery) {
             assert_valid_sql(&build_query(&query));
         }

--- a/api/src/routes/v1/analytics/hero_synergies_stats.rs
+++ b/api/src/routes/v1/analytics/hero_synergies_stats.rs
@@ -343,7 +343,6 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[expect(deprecated)]
         fn hero_synergies_stats_build_query_is_valid_sql(query: HeroSynergyStatsQuery) {
             assert_valid_sql(&build_query(&query));
         }

--- a/api/src/routes/v1/analytics/item_flow_stats.rs
+++ b/api/src/routes/v1/analytics/item_flow_stats.rs
@@ -17,17 +17,14 @@ use crate::error::{APIError, APIResult};
 use crate::routes::v1::matches::types::{GameMode, MatchMode};
 use crate::utils::parse::{comma_separated_deserialize_option, default_last_month_timestamp};
 
-#[expect(clippy::unnecessary_wraps)]
 fn default_min_matches() -> Option<u32> {
     20.into()
 }
 
-#[expect(clippy::unnecessary_wraps)]
 fn default_phase_interval_s() -> Option<u32> {
     600.into()
 }
 
-#[expect(clippy::unnecessary_wraps)]
 fn default_phase_count() -> Option<u8> {
     4.into()
 }

--- a/api/src/routes/v1/analytics/item_flow_stats.rs
+++ b/api/src/routes/v1/analytics/item_flow_stats.rs
@@ -17,17 +17,17 @@ use crate::error::{APIError, APIResult};
 use crate::routes::v1::matches::types::{GameMode, MatchMode};
 use crate::utils::parse::{comma_separated_deserialize_option, default_last_month_timestamp};
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn default_min_matches() -> Option<u32> {
     20.into()
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn default_phase_interval_s() -> Option<u32> {
     600.into()
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn default_phase_count() -> Option<u8> {
     4.into()
 }

--- a/api/src/routes/v1/analytics/item_permutation_stats.rs
+++ b/api/src/routes/v1/analytics/item_permutation_stats.rs
@@ -21,7 +21,7 @@ use crate::utils::parse::{
     comma_separated_deserialize_option, default_last_month_timestamp, parse_steam_id_option,
 };
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn default_comb_size() -> Option<u8> {
     2.into()
 }
@@ -124,7 +124,7 @@ struct ItemPermutationStats {
     matches: u64,
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(query: &ItemPermutationStatsQuery) -> String {
     let info_filters = MatchInfoFilters {
         min_unix_timestamp: query.min_unix_timestamp,
@@ -138,11 +138,11 @@ fn build_query(query: &ItemPermutationStatsQuery) -> String {
     }
     .build();
     let mut hero_ids = query.hero_ids.clone().unwrap_or_default();
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     if let Some(hero_id) = query.hero_id {
         hero_ids.push(hero_id);
     }
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let player_filters = join_filters(
         &PlayerFilters {
             hero_ids: if hero_ids.is_empty() {
@@ -291,7 +291,7 @@ pub(super) async fn item_permutation_stats(
             message: "Cannot filter by average badge for street brawl game mode".to_string(),
         });
     }
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     filter_protected_accounts(&state, &mut query.account_ids, query.account_id).await?;
     if query.comb_size.is_some() && query.item_ids.is_some() {
         return Err(APIError::status_msg(
@@ -314,7 +314,7 @@ pub(super) async fn item_permutation_stats(
 mod tests {
     use super::*;
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn query_with(min_matches: Option<u32>, max_matches: Option<u32>) -> String {
         build_query(&ItemPermutationStatsQuery {
             min_matches,
@@ -353,7 +353,7 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         fn item_permutation_stats_build_query_is_valid_sql(query: ItemPermutationStatsQuery) {
             let sql = build_query(&query);
             if !sql.is_empty() {

--- a/api/src/routes/v1/analytics/item_permutation_stats.rs
+++ b/api/src/routes/v1/analytics/item_permutation_stats.rs
@@ -21,7 +21,6 @@ use crate::utils::parse::{
     comma_separated_deserialize_option, default_last_month_timestamp, parse_steam_id_option,
 };
 
-#[expect(clippy::unnecessary_wraps)]
 fn default_comb_size() -> Option<u8> {
     2.into()
 }
@@ -124,7 +123,6 @@ struct ItemPermutationStats {
     matches: u64,
 }
 
-#[expect(clippy::too_many_lines)]
 fn build_query(query: &ItemPermutationStatsQuery) -> String {
     let info_filters = MatchInfoFilters {
         min_unix_timestamp: query.min_unix_timestamp,
@@ -314,7 +312,6 @@ pub(super) async fn item_permutation_stats(
 mod tests {
     use super::*;
 
-    #[expect(deprecated)]
     fn query_with(min_matches: Option<u32>, max_matches: Option<u32>) -> String {
         build_query(&ItemPermutationStatsQuery {
             min_matches,
@@ -353,7 +350,6 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[expect(deprecated)]
         fn item_permutation_stats_build_query_is_valid_sql(query: ItemPermutationStatsQuery) {
             let sql = build_query(&query);
             if !sql.is_empty() {

--- a/api/src/routes/v1/analytics/item_stats.rs
+++ b/api/src/routes/v1/analytics/item_stats.rs
@@ -1054,13 +1054,11 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[expect(deprecated)]
         fn item_stats_build_query_is_valid_sql(query: ItemStatsQuery) {
             assert_valid_sql(&build_query(&query));
         }
 
         #[test]
-        #[expect(deprecated)]
         fn item_stats_build_mv_query_is_valid_sql(query: ItemStatsQuery) {
             if let Some(sql) = build_mv_query(&query) {
                 assert_valid_sql(&sql);

--- a/api/src/routes/v1/analytics/item_stats.rs
+++ b/api/src/routes/v1/analytics/item_stats.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::large_stack_arrays)]
+#![expect(clippy::large_stack_arrays)]
 
 use axum::Json;
 use axum::extract::State;
@@ -327,13 +327,13 @@ const MV_ROUTING_MARGIN_DAYS: i64 = 5;
 /// request falls within the "global meta" subset it materializes, else `None`
 /// (the caller then uses the base-table query). See `clickhouse/item_stats_agg.sql`
 /// for the grain and the list of what is and isn't covered.
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_mv_query(query: &ItemStatsQuery) -> Option<String> {
     let bucket_expr = query.bucket.mv_bucket_expr()?;
 
     // Fold the deprecated single hero_id into hero_ids.
     let mut hero_ids = query.hero_ids.clone().unwrap_or_default();
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     if let Some(hero_id) = query.hero_id {
         hero_ids.push(hero_id);
     }
@@ -342,7 +342,7 @@ fn build_mv_query(query: &ItemStatsQuery) -> Option<String> {
     // per-purchase data, item-set membership, per-account/enemy context, or a
     // dimension not in the grain (sub-day time, match_id, duration, final net
     // worth, buy time), or a match mode the view does not ingest, must use the base table.
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let personalized = query.account_id.is_some()
         || query.account_ids.as_ref().is_some_and(|v| !v.is_empty())
         || query.enemy_hero_ids.as_ref().is_some_and(|v| !v.is_empty())
@@ -509,7 +509,7 @@ fn build_cohort_mv_query(query: &ItemStatsQuery) -> Option<String> {
     // outside it falls back. Badge bounds use the same >11 / <116 no-op guards
     // as MatchInfoFilters. Hero-filtered cohort queries are deliberately
     // excluded: they are served fast by the base-table projection.
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let unsupported = query.hero_id.is_some()
         || query.hero_ids.as_ref().is_some_and(|v| !v.is_empty())
         || query.account_id.is_some()
@@ -604,7 +604,7 @@ SETTINGS log_comment = 'item_stats_cohort_mv'
 /// `item_cohort_stats_*_agg` rollups. `"eligible"` means the rollup was not declined
 /// (so a routed query must have errored and fallen back). Keep the checks in sync with
 /// `build_cohort_mv_query`'s `None` branches; diagnostic only, no effect on results.
-#[allow(deprecated)]
+#[expect(deprecated)]
 fn cohort_mv_skip_reason(query: &ItemStatsQuery) -> &'static str {
     fn nonempty<T>(v: Option<&[T]>) -> bool {
         v.is_some_and(|v| !v.is_empty())
@@ -728,7 +728,7 @@ fn validate_item_order(chains: Option<&[Vec<u32>]>) -> APIResult<()> {
     Ok(())
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(query: &ItemStatsQuery) -> String {
     /* ---------- match_info filters ---------- */
     let info_filters = MatchInfoFilters {
@@ -745,12 +745,12 @@ fn build_query(query: &ItemStatsQuery) -> String {
 
     /* ---------- match_player filters ---------- */
     let mut hero_ids = query.hero_ids.clone().unwrap_or_default();
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     if let Some(hero_id) = query.hero_id {
         hero_ids.push(hero_id);
     }
     let has_buyer_hero_filter = !hero_ids.is_empty();
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     let mut player_filters = PlayerFilters {
         hero_ids: if hero_ids.is_empty() {
             None
@@ -1036,7 +1036,7 @@ pub(crate) async fn item_stats(
         });
     }
     validate_item_order(query.item_order.as_deref())?;
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     filter_protected_accounts(&state, &mut query.account_ids, query.account_id).await?;
     get_item_stats(&state.ch_client_cached, query)
         .await
@@ -1054,13 +1054,13 @@ mod proptests {
         #![proptest_config(ProptestConfig { cases: 32, max_shrink_iters: 16, failure_persistence: None, .. ProptestConfig::default() })]
 
         #[test]
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         fn item_stats_build_query_is_valid_sql(query: ItemStatsQuery) {
             assert_valid_sql(&build_query(&query));
         }
 
         #[test]
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         fn item_stats_build_mv_query_is_valid_sql(query: ItemStatsQuery) {
             if let Some(sql) = build_mv_query(&query) {
                 assert_valid_sql(&sql);

--- a/api/src/routes/v1/analytics/kill_death_stats.rs
+++ b/api/src/routes/v1/analytics/kill_death_stats.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::large_stack_arrays)]
+#![expect(clippy::large_stack_arrays)]
 
 use axum::Json;
 use axum::extract::State;
@@ -112,7 +112,7 @@ pub(crate) struct KillDeathStats {
     kills: u64,
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(query: &KillDeathStatsQuery) -> String {
     let mut info_filters = vec![];
     if let Some(min_unix_timestamp) = query.min_unix_timestamp {

--- a/api/src/routes/v1/analytics/lane_matchup_stats.rs
+++ b/api/src/routes/v1/analytics/lane_matchup_stats.rs
@@ -27,7 +27,7 @@ use crate::utils::parse::{comma_separated_deserialize_option, default_last_month
 /// Last sample before the recording cadence coarsens from 180s steps to 300s.
 const DEFAULT_SAMPLE_S: u32 = 900;
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn default_sample_time_s() -> Option<u32> {
     Some(DEFAULT_SAMPLE_S)
 }

--- a/api/src/routes/v1/analytics/lane_soul_curve.rs
+++ b/api/src/routes/v1/analytics/lane_soul_curve.rs
@@ -31,7 +31,7 @@ const FIRST_SAMPLE_S: u32 = 180;
 /// `t` and `sample_matchups` lead every sample tuple; each stat then contributes four aggregates.
 const CURVE_TUPLE_LEADING: usize = 2;
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn default_min_time_s() -> Option<u32> {
     Some(FIRST_SAMPLE_S)
 }

--- a/api/src/routes/v1/analytics/player_performance_curve.rs
+++ b/api/src/routes/v1/analytics/player_performance_curve.rs
@@ -19,7 +19,7 @@ use crate::error::{APIError, APIResult};
 use crate::routes::v1::matches::types::{GameMode, MatchMode};
 use crate::utils::parse::{comma_separated_deserialize_option, default_last_month_timestamp};
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn default_resolution() -> Option<u8> {
     10.into()
 }
@@ -170,7 +170,7 @@ pub struct PlayerPerformanceCurvePoint {
     pub gold_death_loss_avg: f64,
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(query: &PlayerPerformanceCurveQuery) -> String {
     let info_filters = MatchInfoFilters {
         min_unix_timestamp: query.min_unix_timestamp,

--- a/api/src/routes/v1/analytics/player_performance_curve.rs
+++ b/api/src/routes/v1/analytics/player_performance_curve.rs
@@ -19,7 +19,6 @@ use crate::error::{APIError, APIResult};
 use crate::routes::v1::matches::types::{GameMode, MatchMode};
 use crate::utils::parse::{comma_separated_deserialize_option, default_last_month_timestamp};
 
-#[expect(clippy::unnecessary_wraps)]
 fn default_resolution() -> Option<u8> {
     10.into()
 }
@@ -170,7 +169,6 @@ pub struct PlayerPerformanceCurvePoint {
     pub gold_death_loss_avg: f64,
 }
 
-#[expect(clippy::too_many_lines)]
 fn build_query(query: &PlayerPerformanceCurveQuery) -> String {
     let info_filters = MatchInfoFilters {
         min_unix_timestamp: query.min_unix_timestamp,

--- a/api/src/routes/v1/analytics/player_scoreboard.rs
+++ b/api/src/routes/v1/analytics/player_scoreboard.rs
@@ -20,7 +20,6 @@ use crate::routes::v1::matches::types::{GameMode, MatchMode};
 use crate::utils::parse::comma_separated_deserialize_option;
 use crate::utils::types::SortDirectionDesc;
 
-#[expect(clippy::unnecessary_wraps)]
 fn default_limit() -> Option<u32> {
     100.into()
 }

--- a/api/src/routes/v1/analytics/player_scoreboard.rs
+++ b/api/src/routes/v1/analytics/player_scoreboard.rs
@@ -20,7 +20,7 @@ use crate::routes::v1::matches::types::{GameMode, MatchMode};
 use crate::utils::parse::comma_separated_deserialize_option;
 use crate::utils::types::SortDirectionDesc;
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn default_limit() -> Option<u32> {
     100.into()
 }

--- a/api/src/routes/v1/analytics/player_stats_metrics.rs
+++ b/api/src/routes/v1/analytics/player_stats_metrics.rs
@@ -210,7 +210,7 @@ impl Metric {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     pub(super) fn extract_values(self, row: &AnalyticsPlayerStatsMetricsRow) -> MetricValues {
         match self {
             Self::Kills => {
@@ -437,7 +437,7 @@ pub(super) struct AnalyticsPlayerStatsMetricsRow {
     quantiles_heal_prevented: Vec<f64>,
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(query: &PlayerStatsMetricsQuery) -> String {
     let info_filters = MatchInfoFilters {
         min_unix_timestamp: query.min_unix_timestamp,

--- a/api/src/routes/v1/analytics/player_stats_metrics.rs
+++ b/api/src/routes/v1/analytics/player_stats_metrics.rs
@@ -437,7 +437,6 @@ pub(super) struct AnalyticsPlayerStatsMetricsRow {
     quantiles_heal_prevented: Vec<f64>,
 }
 
-#[expect(clippy::too_many_lines)]
 fn build_query(query: &PlayerStatsMetricsQuery) -> String {
     let info_filters = MatchInfoFilters {
         min_unix_timestamp: query.min_unix_timestamp,

--- a/api/src/routes/v1/assets/common.rs
+++ b/api/src/routes/v1/assets/common.rs
@@ -53,7 +53,6 @@ pub(crate) struct VersionQuery {
 )]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
-#[expect(clippy::enum_variant_names)]
 pub(crate) enum Language {
     Brazilian,
     Bulgarian,

--- a/api/src/routes/v1/assets/common.rs
+++ b/api/src/routes/v1/assets/common.rs
@@ -53,7 +53,7 @@ pub(crate) struct VersionQuery {
 )]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 pub(crate) enum Language {
     Brazilian,
     Bulgarian,

--- a/api/src/routes/v1/auth/patreon.rs
+++ b/api/src/routes/v1/auth/patreon.rs
@@ -135,7 +135,7 @@ pub(crate) async fn logout(State(state): State<AppState>) -> impl IntoResponse {
 /// 4. Creates or updates patron record in database
 /// 5. Generates JWT session token and sets it as a cookie
 /// 6. Redirects to the frontend redirect URL
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub(crate) async fn callback(
     State(app_state): State<AppState>,
     headers: HeaderMap,

--- a/api/src/routes/v1/auth/webhook.rs
+++ b/api/src/routes/v1/auth/webhook.rs
@@ -29,7 +29,7 @@ fn verify_signature(body: &[u8], secret: &str, signature_hex: &str) -> bool {
 ///
 /// Receives Patreon webhook events, verifies the HMAC-MD5 signature,
 /// and processes membership updates in the background.
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub(crate) async fn webhook(
     State(app_state): State<AppState>,
     headers: HeaderMap,

--- a/api/src/routes/v1/builds/query.rs
+++ b/api/src/routes/v1/builds/query.rs
@@ -6,7 +6,6 @@ use utoipa::{IntoParams, ToSchema};
 use crate::utils::parse::parse_steam_id_option;
 use crate::utils::types::SortDirectionDesc;
 
-#[expect(clippy::unnecessary_wraps)]
 fn default_limit() -> Option<u32> {
     100.into()
 }

--- a/api/src/routes/v1/builds/query.rs
+++ b/api/src/routes/v1/builds/query.rs
@@ -6,7 +6,7 @@ use utoipa::{IntoParams, ToSchema};
 use crate::utils::parse::parse_steam_id_option;
 use crate::utils::types::SortDirectionDesc;
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 fn default_limit() -> Option<u32> {
     100.into()
 }
@@ -119,7 +119,7 @@ impl Default for BuildsSearchQuery {
             search_name: None,
             search_description: None,
             only_latest: None,
-            #[allow(deprecated)]
+            #[expect(deprecated)]
             language: None,
             build_language: None,
             build_id: None,
@@ -161,7 +161,7 @@ pub(super) fn sql_query(params: &BuildsSearchQuery) -> String {
         query_builder.push(search_description.to_lowercase());
         query_builder.push("%'");
     }
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     if let Some(language) = params.language {
         query_builder.push(" AND language = ");
         query_builder.push(language.to_string());

--- a/api/src/routes/v1/commands/variables.rs
+++ b/api/src/routes/v1/commands/variables.rs
@@ -389,7 +389,7 @@ impl Variable {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     pub(super) async fn resolve(
         &self,
         rate_limit_key: &RateLimitKey,

--- a/api/src/routes/v1/graphql/metrics_ext.rs
+++ b/api/src/routes/v1/graphql/metrics_ext.rs
@@ -43,9 +43,9 @@ impl Extension for MetricsExtensionInner {
         metrics::histogram!("graphql_request_duration_seconds").record(elapsed);
 
         if let Some(vr) = self.validation_result.lock().await.take() {
-            #[allow(clippy::cast_precision_loss)]
+            #[expect(clippy::cast_precision_loss)]
             metrics::histogram!("graphql_query_complexity").record(vr.complexity as f64);
-            #[allow(clippy::cast_precision_loss)]
+            #[expect(clippy::cast_precision_loss)]
             metrics::histogram!("graphql_query_depth").record(vr.depth as f64);
         }
 

--- a/api/src/routes/v1/graphql/schema.rs
+++ b/api/src/routes/v1/graphql/schema.rs
@@ -1,6 +1,6 @@
 //! GraphQL schema entry point: `QueryRoot.matches` and `QueryRoot.match_players`.
 
-#![allow(clippy::doc_markdown)]
+#![expect(clippy::doc_markdown)]
 
 use std::sync::Arc;
 
@@ -120,7 +120,7 @@ impl QueryRoot {
         let rows = run_query::<Match>(&state.ch_client_ro, &sql)
             .instrument(info_span!("graphql.clickhouse", operation = "matches", sql = %sql))
             .await?;
-        #[allow(clippy::cast_precision_loss)]
+        #[expect(clippy::cast_precision_loss)]
         metrics::histogram!("graphql_rows_returned", "operation" => "matches")
             .record(rows.len() as f64);
         Ok(rows)
@@ -152,7 +152,7 @@ impl QueryRoot {
         let rows = run_query::<MatchPlayer>(&state.ch_client_ro, &sql)
             .instrument(info_span!("graphql.clickhouse", operation = "match_players", sql = %sql))
             .await?;
-        #[allow(clippy::cast_precision_loss)]
+        #[expect(clippy::cast_precision_loss)]
         metrics::histogram!("graphql_rows_returned", "operation" => "match_players")
             .record(rows.len() as f64);
         Ok(rows)

--- a/api/src/routes/v1/graphql/types.rs
+++ b/api/src/routes/v1/graphql/types.rs
@@ -8,7 +8,7 @@
 //! passthrough — clients still get column-level projection (the SELECT only
 //! includes the requested column) without us having to model dozens of nested
 //! `ClickHouse` types as GraphQL objects in v1.
-#![allow(clippy::struct_field_names)]
+#![expect(clippy::struct_field_names)]
 
 use async_graphql::SimpleObject;
 use serde::{Deserialize, Serialize};

--- a/api/src/routes/v1/info/route.rs
+++ b/api/src/routes/v1/info/route.rs
@@ -113,7 +113,7 @@ async fn fetch_ch_info(ch_client: &clickhouse::Client) -> APIInfo {
                 .map(|row| (row.table.clone(), row.into()))
                 .collect()
         });
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     APIInfo {
         fetched_matches_per_day,
         table_sizes,

--- a/api/src/routes/v1/leaderboard/route.rs
+++ b/api/src/routes/v1/leaderboard/route.rs
@@ -118,7 +118,7 @@ async fn insert_leaderboard_to_ch(
     region: LeaderboardRegion,
     entries: &[c_msg_client_to_gc_get_leaderboard_response::LeaderboardEntry],
 ) {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     let Ok(now) = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs() as u32)
@@ -144,7 +144,7 @@ async fn insert_leaderboard_to_ch(
             region: region as i8,
             account_name: entry.account_name.clone(),
             rank,
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             leaderboard_position: (i as u32) + 1,
             top_hero_ids: entry
                 .top_hero_ids
@@ -168,7 +168,7 @@ async fn insert_hero_leaderboard_to_ch(
     hero_id: u32,
     entries: &[c_msg_client_to_gc_get_leaderboard_response::LeaderboardEntry],
 ) {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     let Ok(now) = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs() as u32)
@@ -195,7 +195,7 @@ async fn insert_hero_leaderboard_to_ch(
             hero_id: u8::try_from(hero_id).unwrap_or_default(),
             account_name: entry.account_name.clone(),
             rank,
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             leaderboard_position: (i as u32) + 1,
             top_hero_ids: entry
                 .top_hero_ids

--- a/api/src/routes/v1/matches/active.rs
+++ b/api/src/routes/v1/matches/active.rs
@@ -56,7 +56,7 @@ fn parse_active_matches_raw(raw_data: &[u8]) -> APIResult<Vec<ActiveMatch>> {
     if raw_data.len() < 7 {
         return Err(APIError::internal("Invalid active matches data"));
     }
-    #[allow(clippy::indexing_slicing)]
+    #[expect(clippy::indexing_slicing)]
     let decompressed_data = snap::raw::Decoder::new().decompress_vec(&raw_data[7..])?;
     let decoded_message =
         CMsgClientToGcGetActiveMatchesResponse::decode(decompressed_data.as_ref())?;
@@ -134,7 +134,7 @@ pub(super) async fn active_matches(
     let mut active_matches = parse_active_matches_raw(&raw_data)?;
 
     // Filter by account id if provided
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     if let Some(account_id) = query.account_id {
         active_matches.retain(|m| {
             m.players

--- a/api/src/routes/v1/matches/bulk_metadata.rs
+++ b/api/src/routes/v1/matches/bulk_metadata.rs
@@ -1,5 +1,5 @@
-#![allow(clippy::struct_excessive_bools)]
-#![allow(clippy::large_stack_arrays)]
+#![expect(clippy::struct_excessive_bools)]
+#![expect(clippy::large_stack_arrays)]
 
 use core::fmt::Write;
 use core::time::Duration;
@@ -427,7 +427,7 @@ async fn players_tuple_type(
     Some(format!("Tuple({fields})"))
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(
     query: BulkMatchMetadataQuery,
     players_tuple_type: Option<&str>,

--- a/api/src/routes/v1/matches/custom/create.rs
+++ b/api/src/routes/v1/matches/custom/create.rs
@@ -227,7 +227,7 @@ The bot will leave the match 15 minutes after creation, regardless of match stat
 | Global | 1000req/h |
 "
 )]
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub(super) async fn create_custom(
     rate_limit_key: RateLimitKey,
     State(mut state): State<AppState>,

--- a/api/src/routes/v1/matches/demo/demofusion/dynamic_builder.rs
+++ b/api/src/routes/v1/matches/demo/demofusion/dynamic_builder.rs
@@ -10,7 +10,7 @@ use haste_core::fieldvalue::FieldValue;
 
 use super::error::Result;
 
-#[allow(
+#[expect(
     clippy::cast_possible_truncation,
     reason = "dynamic FieldValue coerced to the column's declared i32 type"
 )]
@@ -30,7 +30,7 @@ fn push_i64(b: &mut Int64Builder, v: Option<&FieldValue>) {
     }
 }
 
-#[allow(
+#[expect(
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     reason = "dynamic FieldValue coerced to the column's declared u32 type"

--- a/api/src/routes/v1/matches/demo/demofusion/events.rs
+++ b/api/src/routes/v1/matches/demo/demofusion/events.rs
@@ -1,7 +1,7 @@
-#![allow(clippy::all)]
-#![allow(clippy::pedantic)]
-#![allow(unreachable_pub)]
-#![allow(unused_variables)]
+#![expect(clippy::all)]
+#![expect(clippy::pedantic)]
+#![expect(unreachable_pub)]
+#![expect(unused_variables)]
 
 // Include the generated event types and functions
 include!(concat!(env!("OUT_DIR"), "/events_generated.rs"));

--- a/api/src/routes/v1/matches/demo/demofusion/schema/type_mapping.rs
+++ b/api/src/routes/v1/matches/demo/demofusion/schema/type_mapping.rs
@@ -34,7 +34,7 @@ impl FieldType {
             | FieldType::Vector3 { base }
             | FieldType::Vector4 { base } => base.clone(),
             FieldType::FixedArray { element, length } => {
-                #[allow(
+                #[expect(
                     clippy::cast_possible_truncation,
                     clippy::cast_possible_wrap,
                     reason = "fixed-array length comes from proto descriptors and fits in i32"

--- a/api/src/routes/v1/matches/demo/demofusion/visitor/mod.rs
+++ b/api/src/routes/v1/matches/demo/demofusion/visitor/mod.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::std_instead_of_core)]
+#![expect(clippy::std_instead_of_core)]
 
 mod collecting_visitor;
 mod schema_discovery;

--- a/api/src/routes/v1/matches/demo/demofusion/visitor/mod.rs
+++ b/api/src/routes/v1/matches/demo/demofusion/visitor/mod.rs
@@ -1,5 +1,3 @@
-#![expect(clippy::std_instead_of_core)]
-
 mod collecting_visitor;
 mod schema_discovery;
 

--- a/api/src/routes/v1/matches/demo/schema.rs
+++ b/api/src/routes/v1/matches/demo/schema.rs
@@ -157,7 +157,7 @@ pub(super) async fn schema(
 ///
 /// A demo's schema is immutable, so results are cached for 24h keyed on the demo URL,
 /// matching the endpoint's `Cache-Control`.
-#[allow(clippy::std_instead_of_core)]
+#[expect(clippy::std_instead_of_core)]
 async fn fetch_demo_schema(url: &str) -> Result<Vec<TableSchema>, APIError> {
     let response = HTTP_CLIENT
         .get(url)

--- a/api/src/routes/v1/matches/demo/schema.rs
+++ b/api/src/routes/v1/matches/demo/schema.rs
@@ -157,7 +157,6 @@ pub(super) async fn schema(
 ///
 /// A demo's schema is immutable, so results are cached for 24h keyed on the demo URL,
 /// matching the endpoint's `Cache-Control`.
-#[expect(clippy::std_instead_of_core)]
 async fn fetch_demo_schema(url: &str) -> Result<Vec<TableSchema>, APIError> {
     let response = HTTP_CLIENT
         .get(url)

--- a/api/src/routes/v1/matches/types.rs
+++ b/api/src/routes/v1/matches/types.rs
@@ -318,7 +318,7 @@ impl MatchMode {
 }
 
 impl GameMode {
-    #[allow(clippy::unnecessary_wraps)]
+    #[expect(clippy::unnecessary_wraps)]
     pub fn default_option() -> Option<Self> {
         Some(Self::Normal)
     }

--- a/api/src/routes/v1/patches/mod.rs
+++ b/api/src/routes/v1/patches/mod.rs
@@ -17,7 +17,7 @@ use crate::middleware::cache::CacheControlMiddleware;
 )))]
 struct ApiDoc;
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 pub(super) fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::with_openapi(ApiDoc::openapi())
         .routes(routes!(big_patch_days::big_patch_days))

--- a/api/src/routes/v1/patron/steam_accounts.rs
+++ b/api/src/routes/v1/patron/steam_accounts.rs
@@ -64,7 +64,7 @@ pub(crate) struct ListSteamAccountsResponse {
 /// - `SteamID3` must be a valid 32-bit unsigned integer (0 to 4,294,967,295)
 /// - Total active accounts + accounts in cooldown must not exceed `slot_limit`
 /// - The specific `steam_id3` must not be in cooldown (deleted within 24 hours)
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 pub(crate) async fn add_steam_account(
     State(app_state): State<AppState>,
     session: PatronSession,

--- a/api/src/routes/v1/players/hero_stats.rs
+++ b/api/src/routes/v1/players/hero_stats.rs
@@ -111,7 +111,7 @@ pub struct HeroStats {
     matches: Vec<u64>,
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn build_query(query: &HeroStatsQuery) -> String {
     let account_ids = query.account_ids.iter().map(ToString::to_string).join(",");
     let hero_ids_in = query

--- a/api/src/routes/v1/players/mmr/mod.rs
+++ b/api/src/routes/v1/players/mmr/mod.rs
@@ -64,7 +64,7 @@ pub(super) async fn apply_mmr_rate_limits(
     Ok(())
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 pub(super) fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::with_openapi(ApiDoc::openapi())
         .routes(routes!(distribution::mmr_distribution))

--- a/api/src/routes/v1/players/mod.rs
+++ b/api/src/routes/v1/players/mod.rs
@@ -179,7 +179,7 @@ pub(super) async fn resolve_bot_for_account(
     })
 }
 
-#[allow(deprecated)]
+#[expect(deprecated)]
 pub(super) fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::with_openapi(ApiDoc::openapi())
         .routes(routes!(match_history::match_history))

--- a/api/src/routes/v1/players/rank.rs
+++ b/api/src/routes/v1/players/rank.rs
@@ -427,7 +427,7 @@ pub(super) async fn rank_avg_image(
 
     // Badge values are not contiguous (16 is followed by 21), so the average is taken over the
     // badge index rather than the badge itself.
-    #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
     let avg_badge = if badges.is_empty() {
         0
     } else {

--- a/api/src/services/assets/versions/generic_data.rs
+++ b/api/src/services/assets/versions/generic_data.rs
@@ -1,6 +1,6 @@
 //! `/v1/assets/generic-data` data layer — fetch + parse + transform.
 
-#![allow(clippy::struct_field_names, clippy::needless_pass_by_value)]
+#![expect(clippy::struct_field_names, clippy::needless_pass_by_value)]
 
 use std::sync::Arc;
 

--- a/api/src/services/assets/versions/heroes.rs
+++ b/api/src/services/assets/versions/heroes.rs
@@ -22,7 +22,7 @@ const SVGS_BASE_URL: &str = "https://assets-bucket.deadlock-api.com/assets-api-r
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
-#[allow(clippy::struct_field_names)]
+#[expect(clippy::struct_field_names)]
 struct RawStartingStats {
     #[serde(rename = "EMaxMoveSpeed")]
     e_max_move_speed: f64,
@@ -103,7 +103,7 @@ struct RawShopWeaponStatsDisplay {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(clippy::struct_field_names)]
+#[expect(clippy::struct_field_names)]
 struct RawShopStatDisplay {
     #[serde(rename = "m_eSpiritStatsDisplay")]
     e_spirit_stats_display: RawShopSpiritStatsDisplay,
@@ -114,7 +114,7 @@ struct RawShopStatDisplay {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(clippy::struct_field_names)]
+#[expect(clippy::struct_field_names)]
 struct RawHeroStatsDisplay {
     #[serde(rename = "m_vecHealthHeaderStats", default)]
     health_header_stats: Vec<String>,
@@ -200,7 +200,7 @@ pub(crate) struct DraftBucketing {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 struct RawHero {
     #[serde(rename = "m_HeroID")]
     id: u32,
@@ -301,7 +301,7 @@ struct RawHero {
 
 #[derive(Debug, Serialize, Clone, ToSchema, SimpleObject)]
 #[graphql(complex, rename_fields = "snake_case")]
-#[allow(clippy::struct_excessive_bools, clippy::struct_field_names)]
+#[expect(clippy::struct_excessive_bools, clippy::struct_field_names)]
 pub(crate) struct Hero {
     pub id: u32,
     pub class_name: String,
@@ -482,7 +482,7 @@ pub(crate) struct HeroColors {
 
 #[derive(Debug, Serialize, Clone, ToSchema, SimpleObject)]
 #[graphql(rename_fields = "snake_case")]
-#[allow(clippy::struct_field_names)]
+#[expect(clippy::struct_field_names)]
 pub(crate) struct ShopStatDisplay {
     pub spirit_stats_display: ShopSpiritStatsDisplay,
     pub vitality_stats_display: ShopVitalityStatsDisplay,
@@ -515,7 +515,7 @@ pub(crate) struct ShopWeaponStatsDisplay {
 
 #[derive(Debug, Serialize, Clone, ToSchema, SimpleObject)]
 #[graphql(rename_fields = "snake_case")]
-#[allow(clippy::struct_field_names)]
+#[expect(clippy::struct_field_names)]
 pub(crate) struct StatsDisplay {
     pub health_header_stats: Vec<String>,
     pub health_stats: Vec<String>,
@@ -676,7 +676,7 @@ fn transform_root(
     out
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn transform(
     class_name: &str,
     r: RawHero,
@@ -871,7 +871,7 @@ fn build_shop_stat_display(r: RawShopStatDisplay) -> ShopStatDisplay {
     }
 }
 
-#[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
+#[expect(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 fn build_starting_stats(s: &RawStartingStats) -> StartingStats {
     macro_rules! mk {
         ($v:expr, $name:literal) => {

--- a/api/src/services/assets/versions/items/build.rs
+++ b/api/src/services/assets/versions/items/build.rs
@@ -666,7 +666,6 @@ fn build_weapon_info(w: &RawWeaponInfo) -> WeaponInfo {
 
     let cycle_time = w.cycle_time;
     let intra = w.intra_burst_cycle_time.unwrap_or(0.0);
-    #[expect(clippy::cast_precision_loss)]
     let burst = w.burst_shot_count.unwrap_or(1).max(1) as f64;
 
     let shots_per_second = cycle_time.map(|ct| {
@@ -676,14 +675,8 @@ fn build_weapon_info(w: &RawWeaponInfo) -> WeaponInfo {
 
     let shots_per_second_with_reload = match (cycle_time, w.reload_duration, w.clip_size) {
         (Some(ct), Some(rd), Some(clip)) => {
-            #[expect(clippy::cast_precision_loss)]
             let clip_f = clip as f64;
             let recoil_recovery = w.recoil_shot_index_recovery_time_factor.unwrap_or(0.0);
-            #[expect(
-                clippy::cast_precision_loss,
-                clippy::cast_sign_loss,
-                clippy::cast_possible_truncation
-            )]
             let full_bursts = (clip as f64 / burst).floor();
             let total_burst = full_bursts * (burst * intra + ct) - intra;
             let remaining = clip_f % burst;
@@ -1096,7 +1089,6 @@ mod tests {
     const SNAPSHOT_VERSION: u32 = 6064;
     const PUBLIC_BASE: &str = "https://assets-bucket.deadlock-api.com/assets-api-res/versions";
 
-    #[expect(clippy::std_instead_of_core)]
     async fn fetch_zst(client: &reqwest::Client, version: u32, rel: &str) -> String {
         use async_compression::tokio::bufread::ZstdDecoder;
         use tokio::io::AsyncReadExt;

--- a/api/src/services/assets/versions/items/build.rs
+++ b/api/src/services/assets/versions/items/build.rs
@@ -337,7 +337,7 @@ fn webp_of(image: Option<&str>) -> Option<String> {
 
 // ---------- transform ability ----------
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 async fn transform_ability(
     ctx: &TemplateCtx<'_>,
     prop_icons_css: &CssIndex,
@@ -592,7 +592,7 @@ async fn build_ability_tooltip_details(
 
 // ---------- transform weapon ----------
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 fn transform_weapon(
     ctx: &TemplateCtx<'_>,
     prop_icons_css: &CssIndex,
@@ -666,7 +666,7 @@ fn build_weapon_info(w: &RawWeaponInfo) -> WeaponInfo {
 
     let cycle_time = w.cycle_time;
     let intra = w.intra_burst_cycle_time.unwrap_or(0.0);
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     let burst = w.burst_shot_count.unwrap_or(1).max(1) as f64;
 
     let shots_per_second = cycle_time.map(|ct| {
@@ -676,10 +676,10 @@ fn build_weapon_info(w: &RawWeaponInfo) -> WeaponInfo {
 
     let shots_per_second_with_reload = match (cycle_time, w.reload_duration, w.clip_size) {
         (Some(ct), Some(rd), Some(clip)) => {
-            #[allow(clippy::cast_precision_loss)]
+            #[expect(clippy::cast_precision_loss)]
             let clip_f = clip as f64;
             let recoil_recovery = w.recoil_shot_index_recovery_time_factor.unwrap_or(0.0);
-            #[allow(
+            #[expect(
                 clippy::cast_precision_loss,
                 clippy::cast_sign_loss,
                 clippy::cast_possible_truncation
@@ -845,7 +845,7 @@ fn normalize_spread(s: Option<&StringOrFloatList>) -> Option<serde_json::Value> 
 
 // ---------- transform upgrade ----------
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 async fn transform_upgrade(
     ctx: &TemplateCtx<'_>,
     prop_icons_css: &CssIndex,
@@ -1096,7 +1096,7 @@ mod tests {
     const SNAPSHOT_VERSION: u32 = 6064;
     const PUBLIC_BASE: &str = "https://assets-bucket.deadlock-api.com/assets-api-res/versions";
 
-    #[allow(clippy::std_instead_of_core)]
+    #[expect(clippy::std_instead_of_core)]
     async fn fetch_zst(client: &reqwest::Client, version: u32, rel: &str) -> String {
         use async_compression::tokio::bufread::ZstdDecoder;
         use tokio::io::AsyncReadExt;

--- a/api/src/services/assets/versions/items/css_lookup.rs
+++ b/api/src/services/assets/versions/items/css_lookup.rs
@@ -2,7 +2,7 @@
 //! Returns intermediate panorama-style URL strings that the pipeline then
 //! runs through `parse_img_path` to produce public URLs.
 
-#![allow(clippy::doc_markdown)]
+#![expect(clippy::doc_markdown)]
 
 use std::collections::HashMap;
 

--- a/api/src/services/assets/versions/items/mod.rs
+++ b/api/src/services/assets/versions/items/mod.rs
@@ -2,7 +2,7 @@
 //! transform, and cache the public item list. SVG icons are fetched from
 //! the public asset bucket (see `svg`).
 
-#![allow(
+#![expect(
     clippy::too_many_lines,
     clippy::too_many_arguments,
     clippy::case_sensitive_file_extension_comparisons,

--- a/api/src/services/assets/versions/items/mod.rs
+++ b/api/src/services/assets/versions/items/mod.rs
@@ -4,14 +4,9 @@
 
 #![expect(
     clippy::too_many_lines,
-    clippy::too_many_arguments,
     clippy::case_sensitive_file_extension_comparisons,
     clippy::cast_possible_truncation,
-    clippy::cast_precision_loss,
-    clippy::cast_sign_loss,
     clippy::cast_lossless,
-    clippy::large_enum_variant,
-    clippy::module_name_repetitions,
     clippy::similar_names,
     clippy::if_not_else
 )]

--- a/api/src/services/assets/versions/items/raw.rs
+++ b/api/src/services/assets/versions/items/raw.rs
@@ -513,7 +513,7 @@ pub(crate) struct RawWeaponInfoVerticalRecoil {
 
 /// `m_WeaponInfo` for weapon-typed items.
 #[derive(Debug, Deserialize, Clone, Default)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct RawWeaponInfo {
     #[serde(default, rename = "m_bCanZoom")]
     pub(crate) can_zoom: Option<bool>,

--- a/api/src/services/assets/versions/items/raw.rs
+++ b/api/src/services/assets/versions/items/raw.rs
@@ -513,7 +513,6 @@ pub(crate) struct RawWeaponInfoVerticalRecoil {
 
 /// `m_WeaponInfo` for weapon-typed items.
 #[derive(Debug, Deserialize, Clone, Default)]
-#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct RawWeaponInfo {
     #[serde(default, rename = "m_bCanZoom")]
     pub(crate) can_zoom: Option<bool>,

--- a/api/src/services/assets/versions/items/template.rs
+++ b/api/src/services/assets/versions/items/template.rs
@@ -2,7 +2,7 @@
 //! Async because keybind and inline-attribute icons are fetched lazily from
 //! the public asset bucket.
 
-#![allow(clippy::too_many_lines)]
+#![expect(clippy::too_many_lines)]
 
 use std::collections::HashMap;
 use std::sync::OnceLock;

--- a/api/src/services/assets/versions/items/types.rs
+++ b/api/src/services/assets/versions/items/types.rs
@@ -1,7 +1,7 @@
 //! Public `/v1/assets/items` JSON types. Field order matches the legacy
 //! `/v2/items` output so existing clients keep working.
 
-#![allow(
+#![expect(
     clippy::too_many_lines,
     clippy::large_enum_variant,
     clippy::struct_field_names

--- a/api/src/services/assets/versions/items/types.rs
+++ b/api/src/services/assets/versions/items/types.rs
@@ -1,11 +1,7 @@
 //! Public `/v1/assets/items` JSON types. Field order matches the legacy
 //! `/v2/items` output so existing clients keep working.
 
-#![expect(
-    clippy::too_many_lines,
-    clippy::large_enum_variant,
-    clippy::struct_field_names
-)]
+#![expect(clippy::large_enum_variant, clippy::struct_field_names)]
 
 use async_graphql::{ComplexObject, Enum, Json, SimpleObject, Union};
 use indexmap::IndexMap;

--- a/api/src/services/assets/versions/misc_entities.rs
+++ b/api/src/services/assets/versions/misc_entities.rs
@@ -111,7 +111,6 @@ impl utoipa::ToSchema for RollType {
 }
 
 #[derive(Debug, Deserialize)]
-#[expect(clippy::struct_excessive_bools)]
 struct RawMiscEntity {
     #[serde(default, rename = "m_Color")]
     color: Option<Color>,
@@ -238,7 +237,6 @@ pub(crate) enum CurveOrFloat {
 }
 
 #[derive(Debug, Serialize, Clone, ToSchema)]
-#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct MiscEntity {
     pub class_name: String,
     pub id: u32,

--- a/api/src/services/assets/versions/misc_entities.rs
+++ b/api/src/services/assets/versions/misc_entities.rs
@@ -111,7 +111,7 @@ impl utoipa::ToSchema for RollType {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 struct RawMiscEntity {
     #[serde(default, rename = "m_Color")]
     color: Option<Color>,
@@ -238,7 +238,7 @@ pub(crate) enum CurveOrFloat {
 }
 
 #[derive(Debug, Serialize, Clone, ToSchema)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct MiscEntity {
     pub class_name: String,
     pub id: u32,

--- a/api/src/services/assets/versions/npc_units.rs
+++ b/api/src/services/assets/versions/npc_units.rs
@@ -54,7 +54,6 @@ pub(crate) enum SpreadPenalty {
 }
 
 #[derive(Debug, Deserialize)]
-#[expect(clippy::struct_excessive_bools)]
 struct RawWeaponInfo {
     #[serde(default, rename = "m_bCanZoom")]
     can_zoom: Option<bool>,
@@ -254,7 +253,6 @@ struct RawObjectiveHealthGrowthPhase {
 }
 
 #[derive(Debug, Deserialize)]
-#[expect(clippy::struct_excessive_bools)]
 struct RawNpcUnit {
     #[serde(default, rename = "m_WeaponInfo")]
     weapon_info: Option<RawWeaponInfo>,
@@ -409,7 +407,6 @@ pub(crate) struct VerticalRecoil {
 }
 
 #[derive(Debug, Serialize, Clone, Default, ToSchema)]
-#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct WeaponInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub can_zoom: Option<bool>,
@@ -623,7 +620,6 @@ pub(crate) struct ObjectiveHealthGrowthPhase {
 }
 
 #[derive(Debug, Serialize, Clone, ToSchema)]
-#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct NpcUnit {
     pub class_name: String,
     pub id: u32,

--- a/api/src/services/assets/versions/npc_units.rs
+++ b/api/src/services/assets/versions/npc_units.rs
@@ -54,7 +54,7 @@ pub(crate) enum SpreadPenalty {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 struct RawWeaponInfo {
     #[serde(default, rename = "m_bCanZoom")]
     can_zoom: Option<bool>,
@@ -254,7 +254,7 @@ struct RawObjectiveHealthGrowthPhase {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 struct RawNpcUnit {
     #[serde(default, rename = "m_WeaponInfo")]
     weapon_info: Option<RawWeaponInfo>,
@@ -409,7 +409,7 @@ pub(crate) struct VerticalRecoil {
 }
 
 #[derive(Debug, Serialize, Clone, Default, ToSchema)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct WeaponInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub can_zoom: Option<bool>,
@@ -623,7 +623,7 @@ pub(crate) struct ObjectiveHealthGrowthPhase {
 }
 
 #[derive(Debug, Serialize, Clone, ToSchema)]
-#[allow(clippy::struct_excessive_bools)]
+#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct NpcUnit {
     pub class_name: String,
     pub id: u32,
@@ -765,7 +765,7 @@ pub(crate) fn build_npc_units(vdata: &str) -> Result<Vec<NpcUnit>, AssetsError> 
     build_from_kv3(vdata, "npc unit", |_, value| value.is_object(), transform)
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn transform(class_name: String, r: RawNpcUnit) -> NpcUnit {
     let id = entity_id(&class_name);
 
@@ -915,7 +915,7 @@ fn obj_health_phase_out(r: RawObjectiveHealthGrowthPhase) -> ObjectiveHealthGrow
     }
 }
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 fn weapon_info_out(r: RawWeaponInfo) -> WeaponInfo {
     let reload_duration = r.reload_duration_a.or(r.reload_duration_b);
     let cycle_time = r.cycle_time;
@@ -927,7 +927,7 @@ fn weapon_info_out(r: RawWeaponInfo) -> WeaponInfo {
     let bullet_damage = r.bullet_damage;
 
     let shots_per_second = cycle_time.map(|ct| {
-        #[allow(clippy::cast_precision_loss)]
+        #[expect(clippy::cast_precision_loss)]
         let bc = burst_shot_count.unwrap_or(1) as f64;
         let ib = intra_burst.unwrap_or(0.0);
         let adjusted = bc * ib + ct;
@@ -937,25 +937,25 @@ fn weapon_info_out(r: RawWeaponInfo) -> WeaponInfo {
     let shots_per_second_with_reload = match (cycle_time, reload_duration, clip_size) {
         (Some(ct), Some(reload), Some(cs)) => {
             let bc_i = burst_shot_count.unwrap_or(1);
-            #[allow(clippy::cast_precision_loss)]
+            #[expect(clippy::cast_precision_loss)]
             let bc = bc_i as f64;
             let ib = intra_burst.unwrap_or(0.0);
             let recoil = recoil_recov.unwrap_or(0.0);
             let full_bursts = if bc_i == 0 { 0 } else { cs.div_euclid(bc_i) };
             let remaining = if bc_i == 0 { 0 } else { cs.rem_euclid(bc_i) };
-            #[allow(clippy::cast_precision_loss)]
+            #[expect(clippy::cast_precision_loss)]
             let total_burst = (full_bursts as f64) * (bc * ib + ct) - ib;
-            #[allow(clippy::cast_precision_loss)]
+            #[expect(clippy::cast_precision_loss)]
             let total_remaining = (remaining as f64) * ib;
             let total = total_burst + total_remaining + reload + recoil;
-            #[allow(clippy::cast_precision_loss)]
+            #[expect(clippy::cast_precision_loss)]
             let cs_f = cs as f64;
             Some(if total == 0.0 { 0.0 } else { cs_f / total })
         }
         _ => None,
     };
 
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     let bullets_f = bullets.map(|b| b as f64);
     let bps = match (shots_per_second, bullets_f) {
         (Some(s), Some(b)) if s != 0.0 && b != 0.0 => Some(s * b),
@@ -980,7 +980,7 @@ fn weapon_info_out(r: RawWeaponInfo) -> WeaponInfo {
     let dmg_per_mag = match (clip_size, dmg_per_shot) {
         (Some(cs), Some(d)) if cs > 0 && d != 0.0 =>
         {
-            #[allow(clippy::cast_precision_loss)]
+            #[expect(clippy::cast_precision_loss)]
             Some((cs as f64) * d)
         }
         _ => None,

--- a/api/src/services/assets/versions/store.rs
+++ b/api/src/services/assets/versions/store.rs
@@ -148,7 +148,7 @@ async fn fetch_decompressed_cached(
 }
 
 /// Fetch a zstd-compressed object by its full bucket key and decompress it.
-#[allow(clippy::std_instead_of_core)]
+#[expect(clippy::std_instead_of_core)]
 pub(crate) async fn fetch_zst(r2: &AmazonS3, key: &str) -> Result<Bytes, VersionStoreError> {
     debug!("Fetching asset: {key}");
     let res = r2.get(&ObjectPath::from(key.to_owned())).await?;

--- a/api/src/services/assets/versions/store.rs
+++ b/api/src/services/assets/versions/store.rs
@@ -148,7 +148,6 @@ async fn fetch_decompressed_cached(
 }
 
 /// Fetch a zstd-compressed object by its full bucket key and decompress it.
-#[expect(clippy::std_instead_of_core)]
 pub(crate) async fn fetch_zst(r2: &AmazonS3, key: &str) -> Result<Bytes, VersionStoreError> {
     debug!("Fetching asset: {key}");
     let res = r2.get(&ObjectPath::from(key.to_owned())).await?;

--- a/api/src/services/clickhouse_batcher.rs
+++ b/api/src/services/clickhouse_batcher.rs
@@ -245,7 +245,7 @@ async fn batch_loop<I: BatcherInner>(
     }
 }
 
-#[allow(clippy::cast_precision_loss)]
+#[expect(clippy::cast_precision_loss)]
 async fn execute_batch<I: BatcherInner>(
     ch_client: &clickhouse::Client,
     group: &I::Group,

--- a/api/src/services/clickhouse_insert_batcher.rs
+++ b/api/src/services/clickhouse_insert_batcher.rs
@@ -82,12 +82,12 @@ impl<T: BatchInsert> ClickhouseInsertBatcher<T> {
         })
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn signal_shutdown(&self) {
         self.shutdown.store(true, Ordering::Relaxed);
     }
 
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     async fn flush(&self) {
         let rows: Vec<T::Row> = {
             let mut buffer = self.buffer.lock().await;

--- a/api/src/services/patreon/membership.rs
+++ b/api/src/services/patreon/membership.rs
@@ -7,7 +7,6 @@ use super::types::calculate_slot_limit;
 ///
 /// When a patron re-subscribes (pays again) or has a slot override, reactivate their
 /// previously soft-deleted accounts so they don't have to re-add them manually.
-#[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub(crate) async fn handle_reactivation(
     steam_accounts_repository: &SteamAccountsRepository,
     patron_id: uuid::Uuid,

--- a/api/src/services/patreon/membership.rs
+++ b/api/src/services/patreon/membership.rs
@@ -7,7 +7,7 @@ use super::types::calculate_slot_limit;
 ///
 /// When a patron re-subscribes (pays again) or has a slot override, reactivate their
 /// previously soft-deleted accounts so they don't have to re-add them manually.
-#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+#[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub(crate) async fn handle_reactivation(
     steam_accounts_repository: &SteamAccountsRepository,
     patron_id: uuid::Uuid,
@@ -31,7 +31,7 @@ pub(crate) async fn handle_reactivation(
         return Ok(());
     }
 
-    #[allow(clippy::cast_sign_loss)]
+    #[expect(clippy::cast_sign_loss)]
     let available_slots = (slot_limit - active_count) as usize;
 
     let deleted_accounts = steam_accounts_repository
@@ -66,7 +66,7 @@ pub(crate) async fn handle_reactivation(
 /// - If `is_active` is false and patron has no slot override, soft-delete ALL accounts
 /// - If patron has a slot override, respect that limit even when subscription is inactive
 /// - If new slot limit < active accounts count, soft-delete oldest accounts first
-#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+#[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
 pub(crate) async fn handle_downgrade_or_cancellation(
     steam_accounts_repository: &SteamAccountsRepository,
     patron_id: uuid::Uuid,

--- a/api/src/services/patreon/repository.rs
+++ b/api/src/services/patreon/repository.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use chrono::{DateTime, Utc};
 use sqlx::{Pool, Postgres};

--- a/api/src/services/patreon/steam_accounts_repository.rs
+++ b/api/src/services/patreon/steam_accounts_repository.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use cached::CachedExt;
 use chrono::{DateTime, Duration, Utc};
@@ -113,7 +113,7 @@ impl SteamAccountsRepository {
     }
 
     /// Counts active (non-deleted) Steam accounts for a patron.
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     pub(crate) async fn count_active_accounts(
         &self,
         patron_id: Uuid,
@@ -135,7 +135,7 @@ impl SteamAccountsRepository {
     }
 
     /// Counts Steam accounts in cooldown (deleted within the last 24 hours) for a patron.
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     pub(crate) async fn count_accounts_in_cooldown(
         &self,
         patron_id: Uuid,

--- a/api/src/services/patreon/types.rs
+++ b/api/src/services/patreon/types.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![expect(dead_code)]
 
 use aes_gcm::Aes256Gcm;
 use aes_gcm::aead::{Aead, Generate, Key, KeyInit, Nonce};
@@ -179,7 +179,7 @@ pub(crate) fn calculate_slot_limit(
         if pledge_amount_cents <= 0 {
             0
         } else {
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             let slots = (f64::from(pledge_amount_cents) / 150.0).round() as i32;
             slots.clamp(1, 50)
         }

--- a/api/src/services/patreon/verification_job.rs
+++ b/api/src/services/patreon/verification_job.rs
@@ -115,7 +115,7 @@ impl PatreonVerificationJob {
     }
 
     /// Signal shutdown
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn signal_shutdown(&self) {
         self.shutdown.store(true, Ordering::Relaxed);
     }

--- a/api/src/services/patreon/webhook_types.rs
+++ b/api/src/services/patreon/webhook_types.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 
 /// Patreon webhook event types parsed from the `X-Patreon-Event` header.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 pub(crate) enum PatreonWebhookEvent {
     MembersCreate,
     MembersUpdate,

--- a/api/src/services/rate_limiter/client.rs
+++ b/api/src/services/rate_limiter/client.rs
@@ -186,9 +186,9 @@ impl RateLimitClient {
         Ok(rows
             .iter()
             .map(|row| Quota {
-                #[allow(clippy::cast_sign_loss)]
+                #[expect(clippy::cast_sign_loss)]
                 limit: row.rate_limit as usize,
-                #[allow(clippy::cast_sign_loss)]
+                #[expect(clippy::cast_sign_loss)]
                 period: Duration::from_micros(row.rate_period.microseconds as u64),
                 r#type: QuotaType::Key,
             })

--- a/api/src/services/request_logger/mod.rs
+++ b/api/src/services/request_logger/mod.rs
@@ -62,7 +62,7 @@ impl RequestLogger {
     }
 
     /// Signal shutdown and wait for the background task to complete
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn signal_shutdown(&self) {
         self.shutdown.store(true, Ordering::Relaxed);
     }

--- a/api/src/services/steam/client.rs
+++ b/api/src/services/steam/client.rs
@@ -100,7 +100,7 @@ impl SteamClient {
         body: &T,
     ) -> SteamProxyResult<SteamProxyRawResponse> {
         let url = if self.steam_proxy_urls.len() == 1 {
-            #[allow(clippy::indexing_slicing, reason = "We checked the length")]
+            #[expect(clippy::indexing_slicing, reason = "We checked the length")]
             &self.steam_proxy_urls[0]
         } else {
             self.steam_proxy_urls

--- a/api/src/services/steam_search_index.rs
+++ b/api/src/services/steam_search_index.rs
@@ -1,11 +1,7 @@
 // Casts in this module either round-trip u32 through Tantivy's u64 FAST fields
 // (safe by construction) or feed jaro-winkler math that doesn't care about
 // sub-f64 precision on tiny strings.
-#![expect(
-    clippy::cast_precision_loss,
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap
-)]
+#![expect(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 
 use core::fmt::Display;
 use core::ops::Bound;

--- a/api/src/services/steam_search_index.rs
+++ b/api/src/services/steam_search_index.rs
@@ -1,7 +1,7 @@
 // Casts in this module either round-trip u32 through Tantivy's u64 FAST fields
 // (safe by construction) or feed jaro-winkler math that doesn't care about
 // sub-f64 precision on tiny strings.
-#![allow(
+#![expect(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap
@@ -335,7 +335,7 @@ impl SteamSearchIndex {
 
     /// Search the index. Returns up to `limit` profiles ranked by
     /// `jaro_winkler(personaname_lc, query) + matches_played_weight * log1p(matches)`.
-    #[allow(clippy::too_many_lines)]
+    #[expect(clippy::too_many_lines)]
     pub(crate) fn search(
         &self,
         query: &str,

--- a/api/src/test_helpers.rs
+++ b/api/src/test_helpers.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 /// Convenience wrapper around the heroes pipeline that returns the same
 /// `Vec<Value>` the public endpoint serves, so snapshot tests don't need
 /// access to the private `Hero` types.
-#[allow(clippy::implicit_hasher)]
+#[expect(clippy::implicit_hasher)]
 pub fn build_heroes_json(
     heroes_vdata: &str,
     localization: &HashMap<String, String>,

--- a/api/src/utils/kv3.rs
+++ b/api/src/utils/kv3.rs
@@ -706,7 +706,7 @@ mod tests {
                 f();
             }
             let avg: Duration = t0.elapsed() / n;
-            #[allow(clippy::cast_precision_loss)]
+            #[expect(clippy::cast_precision_loss)]
             let mb = (len as f64) / avg.as_secs_f64() / 1024.0 / 1024.0;
             println!("{label:>32}: {len} bytes, avg {avg:?}, {mb:.1} MB/s");
         }

--- a/api/src/utils/parse.rs
+++ b/api/src/utils/parse.rs
@@ -236,7 +236,6 @@ pub(crate) fn default_last_month_timestamp() -> Option<i64> {
     last_month.and_utc().timestamp().into()
 }
 
-#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn default_true_option() -> Option<bool> {
     true.into()
 }

--- a/api/src/utils/parse.rs
+++ b/api/src/utils/parse.rs
@@ -236,7 +236,7 @@ pub(crate) fn default_last_month_timestamp() -> Option<i64> {
     last_month.and_utc().timestamp().into()
 }
 
-#[allow(clippy::unnecessary_wraps)]
+#[expect(clippy::unnecessary_wraps)]
 pub(crate) fn default_true_option() -> Option<bool> {
     true.into()
 }

--- a/live-events/src/demo_parser/entity_events.rs
+++ b/live-events/src/demo_parser/entity_events.rs
@@ -5,7 +5,10 @@ use haste::parser::Context;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString, FromRepr, VariantArray};
 
-#[allow(clippy::wildcard_imports)]
+#[allow(
+    clippy::wildcard_imports,
+    reason = "`expect` on a `use` item is not fulfilled"
+)]
 use crate::demo_parser::hashes::*;
 use crate::demo_parser::types::Delta;
 use crate::demo_parser::utils;

--- a/live-events/src/demo_parser/utils.rs
+++ b/live-events/src/demo_parser/utils.rs
@@ -1,6 +1,9 @@
 use haste::entities::{Entity, deadlock_coord_from_cell};
 
-#[allow(clippy::wildcard_imports)]
+#[allow(
+    clippy::wildcard_imports,
+    reason = "`expect` on a `use` item is not fulfilled"
+)]
 use crate::demo_parser::hashes::*;
 
 fn get_entity_coord(entity: &Entity, cell_key: u64, vec_key: u64) -> Option<f32> {

--- a/live-events/src/demo_parser/visitor.rs
+++ b/live-events/src/demo_parser/visitor.rs
@@ -205,7 +205,7 @@ impl SendingVisitor {
     }
 
     fn handle_tick_end(&mut self, ctx: &Context) -> Result<(), DemoParseError> {
-        #[allow(clippy::cast_precision_loss)]
+        #[expect(clippy::cast_precision_loss)]
         {
             let ticks = ctx.tick() - self.rules.total_paused_ticks.unwrap_or_default();
             let total_time = ticks as f32 * self.tick_interval;

--- a/live-events/src/error.rs
+++ b/live-events/src/error.rs
@@ -20,7 +20,7 @@ pub enum StartupError {
     AppState(#[from] AppStateError),
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Debug, Error)]
 pub(super) enum APIError {
     #[error("Status {status}")]

--- a/live-events/src/lib.rs
+++ b/live-events/src/lib.rs
@@ -8,8 +8,8 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::unreadable_literal)]
-#![allow(clippy::missing_errors_doc)]
+#![expect(clippy::unreadable_literal)]
+#![expect(clippy::missing_errors_doc)]
 
 mod demo;
 mod demo_parser;

--- a/live-events/src/state.rs
+++ b/live-events/src/state.rs
@@ -20,7 +20,6 @@ pub(crate) struct AppState {
 }
 
 impl AppState {
-    #[allow(clippy::too_many_lines)]
     pub(crate) fn from_env() -> Result<AppState, AppStateError> {
         let config = serde_env::from_env()?;
         let http_client = reqwest::Client::new();

--- a/tools/active-matches-scraper/src/main.rs
+++ b/tools/active-matches-scraper/src/main.rs
@@ -8,7 +8,7 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::cast_precision_loss)]
+#![expect(clippy::cast_precision_loss)]
 
 mod models;
 

--- a/tools/builds-fetcher/src/main.rs
+++ b/tools/builds-fetcher/src/main.rs
@@ -8,8 +8,8 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::cast_possible_wrap)]
+#![expect(clippy::cast_precision_loss)]
+#![expect(clippy::cast_possible_wrap)]
 
 use core::time::Duration;
 

--- a/tools/builds-fetcher/src/main.rs
+++ b/tools/builds-fetcher/src/main.rs
@@ -8,7 +8,6 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![expect(clippy::cast_precision_loss)]
 #![expect(clippy::cast_possible_wrap)]
 
 use core::time::Duration;

--- a/tools/common/src/lib.rs
+++ b/tools/common/src/lib.rs
@@ -8,9 +8,9 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::unreadable_literal)]
+#![expect(clippy::missing_errors_doc)]
+#![expect(clippy::cast_possible_truncation)]
+#![expect(clippy::unreadable_literal)]
 
 mod assets;
 mod clients;

--- a/tools/common/src/utils.rs
+++ b/tools/common/src/utils.rs
@@ -45,7 +45,7 @@ pub struct SteamProxyResponse {
     pub username: String,
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 #[instrument(skip(http_client, msg))]
 pub async fn call_steam_proxy<T: Message + Default>(
     http_client: &reqwest::Client,

--- a/tools/demo-analyzer/src/main.rs
+++ b/tools/demo-analyzer/src/main.rs
@@ -8,10 +8,7 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![expect(clippy::cast_sign_loss)]
 #![expect(clippy::cast_precision_loss)]
-#![expect(clippy::cast_possible_truncation)]
-#![expect(clippy::struct_field_names)]
 
 use core::time::Duration;
 use std::collections::{HashMap, HashSet};

--- a/tools/demo-analyzer/src/main.rs
+++ b/tools/demo-analyzer/src/main.rs
@@ -8,10 +8,10 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::cast_sign_loss)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::struct_field_names)]
+#![expect(clippy::cast_sign_loss)]
+#![expect(clippy::cast_precision_loss)]
+#![expect(clippy::cast_possible_truncation)]
+#![expect(clippy::struct_field_names)]
 
 use core::time::Duration;
 use std::collections::{HashMap, HashSet};

--- a/tools/friends-rank-fetcher/src/main.rs
+++ b/tools/friends-rank-fetcher/src/main.rs
@@ -8,7 +8,7 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::cast_precision_loss)]
+#![expect(clippy::cast_precision_loss)]
 
 use core::time::Duration;
 

--- a/tools/history-fetcher/src/main.rs
+++ b/tools/history-fetcher/src/main.rs
@@ -8,8 +8,8 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::cast_possible_truncation)]
+#![expect(clippy::cast_precision_loss)]
+#![expect(clippy::cast_possible_truncation)]
 
 mod types;
 
@@ -553,7 +553,7 @@ async fn get_due_prioritized_accounts(accounts: &PrioritizedAccountsMap) -> Vec<
                     );
                     counter!("history_fetcher.prioritized_fetch.sla_breach").increment(1);
                 }
-                #[allow(clippy::cast_sign_loss)]
+                #[expect(clippy::cast_sign_loss)]
                 Some((steam_id3 as u32, bot_id.clone()))
             } else {
                 None

--- a/tools/hltv-scraper/src/active_matches.rs
+++ b/tools/hltv-scraper/src/active_matches.rs
@@ -14,7 +14,7 @@ pub(crate) struct ActiveMatch {
     pub match_score: Option<u32>,
 }
 
-#[allow(unused)]
+#[expect(unused)]
 impl ActiveMatch {
     pub(crate) fn is_core_exposed(&self) -> bool {
         use ECitadelTeamObjective::KECitadelTeamObjectiveTitan;

--- a/tools/hltv-scraper/src/hltv/hltv_download.rs
+++ b/tools/hltv-scraper/src/hltv/hltv_download.rs
@@ -13,7 +13,7 @@ use tracing::{error, trace};
 use crate::hltv::FragmentType;
 use crate::hltv::hltv_extract_meta::analyze_fragment;
 
-#[allow(unused)]
+#[expect(unused)]
 #[derive(Debug)]
 pub(crate) struct HltvFragment {
     pub match_id: u64,
@@ -42,7 +42,7 @@ pub(crate) enum DownloadError {
     ReceiverDropped,
 }
 
-#[allow(unused)]
+#[expect(unused)]
 #[derive(Deserialize)]
 struct SyncResponse {
     tick: u64,

--- a/tools/hltv-scraper/src/hltv/hltv_extract_meta.rs
+++ b/tools/hltv-scraper/src/hltv/hltv_extract_meta.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::std_instead_of_core)]
+#![expect(clippy::std_instead_of_core)]
 
 use std::io::Cursor;
 use std::sync::Arc;

--- a/tools/hltv-scraper/src/hltv/hltv_extract_meta.rs
+++ b/tools/hltv-scraper/src/hltv/hltv_extract_meta.rs
@@ -1,4 +1,3 @@
-
 use std::io::Cursor;
 use std::sync::Arc;
 

--- a/tools/hltv-scraper/src/hltv/hltv_extract_meta.rs
+++ b/tools/hltv-scraper/src/hltv/hltv_extract_meta.rs
@@ -1,4 +1,3 @@
-#![expect(clippy::std_instead_of_core)]
 
 use std::io::Cursor;
 use std::sync::Arc;

--- a/tools/hltv-scraper/src/main.rs
+++ b/tools/hltv-scraper/src/main.rs
@@ -8,12 +8,12 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::cast_sign_loss)]
-#![allow(clippy::cast_possible_wrap)]
-#![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::too_many_lines)]
-#![allow(clippy::unreadable_literal)]
+#![expect(clippy::cast_precision_loss)]
+#![expect(clippy::cast_sign_loss)]
+#![expect(clippy::cast_possible_wrap)]
+#![expect(clippy::cast_possible_truncation)]
+#![expect(clippy::too_many_lines)]
+#![expect(clippy::unreadable_literal)]
 
 use crate::cli::run_cli;
 

--- a/tools/hltv-scraper/src/main.rs
+++ b/tools/hltv-scraper/src/main.rs
@@ -10,7 +10,6 @@
 #![deny(clippy::std_instead_of_core)]
 #![expect(clippy::cast_precision_loss)]
 #![expect(clippy::cast_sign_loss)]
-#![expect(clippy::cast_possible_wrap)]
 #![expect(clippy::cast_possible_truncation)]
 #![expect(clippy::too_many_lines)]
 #![expect(clippy::unreadable_literal)]

--- a/tools/ingest-worker/src/main.rs
+++ b/tools/ingest-worker/src/main.rs
@@ -8,10 +8,10 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::cast_sign_loss)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::struct_field_names)]
+#![expect(clippy::cast_sign_loss)]
+#![expect(clippy::cast_precision_loss)]
+#![expect(clippy::cast_possible_truncation)]
+#![expect(clippy::struct_field_names)]
 
 use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use core::time::Duration;

--- a/tools/ingest-worker/src/main.rs
+++ b/tools/ingest-worker/src/main.rs
@@ -11,7 +11,6 @@
 #![expect(clippy::cast_sign_loss)]
 #![expect(clippy::cast_precision_loss)]
 #![expect(clippy::cast_possible_truncation)]
-#![expect(clippy::struct_field_names)]
 
 use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use core::time::Duration;

--- a/tools/ingest-worker/src/models/clickhouse_match_metadata.rs
+++ b/tools/ingest-worker/src/models/clickhouse_match_metadata.rs
@@ -300,7 +300,7 @@ fn average_badge(match_info: &MatchInfo) -> Option<u32> {
 /// even would starve odd ranks of that mass and leave a sawtooth in the rank distribution.
 ///
 /// Callers filter out zero badges, so the dense mean is at least 1.
-#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn mean_badge(badges: &[u32]) -> Option<u32> {
     let count = u32::try_from(badges.len()).ok().filter(|c| *c > 0)?;
     let dense_sum: u32 = badges.iter().map(|badge| badge - 4 * (badge / 10)).sum();
@@ -313,7 +313,7 @@ fn mean_badge(badges: &[u32]) -> Option<u32> {
 /// sub-16-unit precision. Trades imperceptible accuracy for ~36% smaller `x_pos`/`y_pos`.
 const POS_QUANTIZATION_MASK: u16 = 0xFFF0;
 
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 impl From<(&MatchInfo, bool, Option<&Path>, Players)> for ClickhouseMatchPlayer {
     fn from(
         (match_info, won, match_path, value): (&MatchInfo, bool, Option<&Path>, Players),

--- a/tools/matchdata-downloader/src/main.rs
+++ b/tools/matchdata-downloader/src/main.rs
@@ -8,7 +8,7 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::cast_precision_loss)]
+#![expect(clippy::cast_precision_loss)]
 
 use core::time::Duration;
 use std::collections::{HashMap, HashSet};

--- a/tools/matchdata-downloader/src/models.rs
+++ b/tools/matchdata-downloader/src/models.rs
@@ -14,7 +14,7 @@ pub(crate) struct MatchSalts {
 }
 
 /// Salts are secrets: anyone holding one can pull the replay.
-#[allow(clippy::missing_fields_in_debug)]
+#[expect(clippy::missing_fields_in_debug)]
 impl Debug for MatchSalts {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("MatchSalts")

--- a/tools/salt-scraper/src/main.rs
+++ b/tools/salt-scraper/src/main.rs
@@ -8,7 +8,7 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::cast_precision_loss)]
+#![expect(clippy::cast_precision_loss)]
 
 use core::time::Duration;
 use std::sync::LazyLock;
@@ -46,7 +46,7 @@ static PRIORITIZATION_MAX_RETRIES: LazyLock<u32> =
     LazyLock::new(|| common::env_or("PRIORITIZATION_MAX_RETRIES", 5));
 
 #[tokio::main]
-#[allow(clippy::too_many_lines)]
+#[expect(clippy::too_many_lines)]
 async fn main() -> anyhow::Result<()> {
     let _otel_guard = common::init_tracing(env!("CARGO_PKG_NAME"));
     common::init_metrics()?;

--- a/tools/steam-profile-fetcher/src/main.rs
+++ b/tools/steam-profile-fetcher/src/main.rs
@@ -8,9 +8,9 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![allow(clippy::unreadable_literal)]
-#![allow(clippy::cast_precision_loss)]
-#![allow(clippy::cast_possible_truncation)]
+#![expect(clippy::unreadable_literal)]
+#![expect(clippy::cast_precision_loss)]
+#![expect(clippy::cast_possible_truncation)]
 
 use core::time::Duration;
 use std::collections::{HashMap, HashSet};

--- a/tools/steam-profile-fetcher/src/main.rs
+++ b/tools/steam-profile-fetcher/src/main.rs
@@ -8,7 +8,6 @@
 #![deny(clippy::perf)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::std_instead_of_core)]
-#![expect(clippy::unreadable_literal)]
 #![expect(clippy::cast_precision_loss)]
 #![expect(clippy::cast_possible_truncation)]
 


### PR DESCRIPTION
## Description

Converts every lint suppression attribute from `allow` to `expect` across the three Rust crates (`api/`, `tools/`, `live-events/`).

`expect` suppresses the lint exactly like `allow`, but rustc emits `unfulfilled_lint_expectations` when the lint no longer fires — so a suppression that has become obsolete shows up as a warning (and, under CI's `-D warnings`, as a failure) instead of silently rotting in the tree.

**220 attributes converted** across 96 files — item-level attributes and crate/module-level inner attributes alike. Attribute contents, `reason = "..."` fields, and trailing explanatory comments are otherwise untouched.

Two categories needed more than a mechanical rename.

### Stale suppressions removed (62)

These no longer suppress anything — `expect` reported each as unfulfilled. Rather than reverting them to `allow` and keeping dead attributes around, they were deleted. In multi-lint attributes only the dead entries were dropped, leaving the live ones in place (e.g. `services/assets/versions/items/mod.rs` keeps 6 of its 11 crate-level lints).

- **`api/` — 53**, spread over `lib.rs`, most of `routes/v1/analytics/*`, `services/assets/versions/*`, `services/patreon/membership.rs`, `services/steam_search_index.rs`, `utils/parse.rs` and others. Notably `clippy::needless_for_each` at the crate root, whose comment pointed at [utoipa#1423](https://github.com/juhaku/utoipa/pull/1423) — that workaround is no longer needed.
- **`tools/` — 8** crate-level suppressions in `steam-profile-fetcher`, `builds-fetcher`, `demo-analyzer`, `hltv-scraper` and `ingest-worker`.
- **`live-events/` — 1**: `clippy::too_many_lines` on `AppState::from_env`.

### Three suppressions deliberately kept as `allow`

Each has a `reason` explaining why, so they don't get "fixed" later:

- `live-events/src/demo_parser/entity_events.rs` and `.../utils.rs` — `clippy::wildcard_imports` on `use crate::demo_parser::hashes::*;`. An `expect` on a `use` item is not matched by the lint clippy emits there, so converting produces an unfulfilled-expectation warning *and* the wildcard-import error at the same time.
- `api/src/error.rs` — `dead_code` on `APIError`. The type is used by tests, so `expect` is fulfilled in the lib build but unfulfilled in the test build; `--all-targets` fails either way round.

These are the only three `allow` attributes left in the repo.

## Related Issue

n/a — no linked issue.

## Type of Change

- [x] Code refactoring (no functional changes)

## How Has This Been Tested?

- [x] Manual testing

No behavioral change: `expect` and `allow` suppress lints identically, so this is compile-time-only. Verified locally with the same commands the pre-push hook and CI run — all clean, and since confirmed green in CI:

- `api`: `cargo clippy --all-targets --locked -- -D warnings`
- `tools`: `cargo clippy --all-targets --locked --all-features -- -D warnings`
- `live-events`: `cargo clippy --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check` in all three crates

Deciding delete-vs-keep required running clippy per target, since an expectation can be fulfilled in the lib build and unfulfilled in the test build — that is exactly how the `api/src/error.rs` case above surfaced.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas — `reason` added to the three retained `allow`s
- [ ] I have made corresponding changes to the documentation — n/a
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — n/a, no behavior change
- [x] New and existing unit tests pass locally with my changes — the `Test` job is green

## Additional Notes

Going forward, an obsolete suppression surfaces as a CI failure rather than lingering — which is exactly what turned up the 62 stale ones above.