### PR TITLE
website: swap React Compiler from Babel to the Rust (oxc) port

### DIFF
--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -15,7 +15,7 @@ tanstack-start
 ├── content/blog/               # markdown blog posts (bundled at build time via Vite glob)
 ├── public
 │   └── _headers                # Cloudflare security headers
-├── vite.config.ts              # @tanstack/react-start plugin + Tailwind v4 + React Compiler (prod only)
+├── vite.config.ts              # @tanstack/react-start plugin + Tailwind v4 + React Compiler (oxc)
 ├── wrangler.jsonc              # Workers config: main=dist/server/server.js, assets=dist/client
 ├── components.json             # shadcn aliases (~/ -> src/)
 ├── .oxlintrc.jsonc / .oxfmtrc.json
@@ -63,7 +63,15 @@ Requires `wrangler login` (or `CLOUDFLARE_API_TOKEN`) and a Cloudflare account c
 
 ## Conventions
 
-- React Compiler runs only in production builds (slow in dev) via `vite-plugin-babel`.
+- React Compiler runs in every build, dev included, via `@vitejs/plugin-react`'s `compiler`
+  option. That option is backed by `oxc-transform-react` — the Rust port of React Compiler —
+  which runs in the same oxc pass as the TypeScript and JSX transforms, so it is cheap enough
+  not to need the production-only gate the old Babel plugin did.
+- Constructs the compiler cannot lower (`try`/`finally`, `throw` inside `try`, `++`/`--` on a
+  captured variable) leave that component unoptimized. The Babel plugin skipped them silently;
+  the oxc one prints them as `react-compiler(Todo)` build warnings. The set of skipped
+  components is the same — the warnings are new, the behaviour is not — so treat them as a
+  to-do list, not a build failure.
 - shadcn primitives live in `src/components/ui/`. Add new ones with `pnpm dlx shadcn@latest add <component>` against the existing `components.json`.
 - Tailwind v4: `@plugin` directives in `tailwind.css` for typography/iconify/animations (no JS plugin array).
 - TypeScript override `^6.0.3` is enforced via `package.json > pnpm.overrides`.

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -63,15 +63,8 @@ Requires `wrangler login` (or `CLOUDFLARE_API_TOKEN`) and a Cloudflare account c
 
 ## Conventions
 
-- React Compiler runs in every build, dev included, via `@vitejs/plugin-react`'s `compiler`
-  option. That option is backed by `oxc-transform-react` — the Rust port of React Compiler —
-  which runs in the same oxc pass as the TypeScript and JSX transforms, so it is cheap enough
-  not to need the production-only gate the old Babel plugin did.
-- Constructs the compiler cannot lower (`try`/`finally`, `throw` inside `try`, `++`/`--` on a
-  captured variable) leave that component unoptimized. The Babel plugin skipped them silently;
-  the oxc one prints them as `react-compiler(Todo)` build warnings. The set of skipped
-  components is the same — the warnings are new, the behaviour is not — so treat them as a
-  to-do list, not a build failure.
+- React Compiler runs in every build, dev included, via `@vitejs/plugin-react`'s `compiler` option — backed by `oxc-transform-react` (the Rust port), which shares the oxc pass with the TypeScript and JSX transforms and so needs no production-only gate.
+- Constructs it cannot lower (`try`/`finally`, `throw` inside `try`, `++`/`--` on a captured variable) leave that component unoptimized and print a `react-compiler(Todo)` warning. Same components the Babel plugin skipped silently — a to-do list, not a build failure.
 - shadcn primitives live in `src/components/ui/`. Add new ones with `pnpm dlx shadcn@latest add <component>` against the existing `components.json`.
 - Tailwind v4: `@plugin` directives in `tailwind.css` for typography/iconify/animations (no JS plugin array).
 - TypeScript override `^6.0.3` is enforced via `package.json > pnpm.overrides`.

--- a/website/package.json
+++ b/website/package.json
@@ -66,16 +66,15 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@types/three": "^0.184.1",
-    "@vitejs/plugin-react": "^6.0.5",
+    "@vitejs/plugin-react": "^6.1.0",
     "agentation": "^3.0.2",
-    "babel-plugin-react-compiler": "^1.0.0",
     "eslint-plugin-react-hooks": "^7.1.1",
+    "oxc-transform-react": "^0.145.0",
     "oxfmt": "^0.54.0",
     "oxlint": "^1.76.0",
     "tsx": "^4.23.1",
     "typescript": "^6.0.3",
     "vite": "^8.2.0",
-    "vite-plugin-babel": "^1.7.3",
     "wrangler": "^4.118.0"
   },
   "engines": {

--- a/website/package.json
+++ b/website/package.json
@@ -75,7 +75,7 @@
     "tsx": "^4.23.1",
     "typescript": "^6.0.3",
     "vite": "^8.2.0",
-    "wrangler": "^4.118.0"
+    "wrangler": "^4.126.0"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   typescript: ^6.0.3
+  nanoid: ^3.3.18
 
 importers:
 
@@ -190,8 +191,8 @@ importers:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)
       wrangler:
-        specifier: ^4.118.0
-        version: 4.118.0
+        specifier: ^4.126.0
+        version: 4.126.0
 
 packages:
 
@@ -348,32 +349,32 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260730.1':
-    resolution: {integrity: sha512-+MBHmPaiTe2KajryW0T24rZvWFxb41hD3d8anNzQqHzft6vSEb18+sp0znSwxgij7ApPhSM1+vhkNg4f3YMguA==}
+  '@cloudflare/workerd-darwin-64@1.20260825.1':
+    resolution: {integrity: sha512-oHu38dwaUuzAilyTb0QkQ1YxU/kzqzIQybCvQKAhiK1CGtQS9h0MmjIZYogv3g8cFGGY2k+Wxs0wV9hHK8z78g==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260730.1':
-    resolution: {integrity: sha512-SBHKntPkKvNPgaCrTe99xC1CAl8ygJDzlYfK0LbuJ1muKadIw35WnhO0wu894fKBtllsVQdNzDLee+cm0ppLSQ==}
+  '@cloudflare/workerd-darwin-arm64@1.20260825.1':
+    resolution: {integrity: sha512-ak5zh8YGEjxQQ78bVo7gzU+tcg2fSFxMIjOPZtWk56a/rIYLbGu6ECcliqnYfMUlragg68H0JuVpfdr3BR5Alw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260730.1':
-    resolution: {integrity: sha512-ouyPOSMbiKPeSwUJUvxtMcxGAXs2J4aPE4T5ABIYX5ClcQx5j5bbHTmnqOQEY8sAuLTPjH7dY+iB6UI5ISlwwA==}
+  '@cloudflare/workerd-linux-64@1.20260825.1':
+    resolution: {integrity: sha512-bNQvzz6NemWAwixDRz1fQa5T+E5lS4xpB7A/H/72ULxrjVpHmq8CGFPSbdmRp3dvgBjZTgp7wHdGLISLSVd9Gg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260730.1':
-    resolution: {integrity: sha512-YQ+Mi78U3TPdgBPtwq+Sm6rJU+Ihl2y0pjYtuuKkdmUbYzL7oLR6Xqq9wljhasnuCFICssDJaqhMep5WizYoEQ==}
+  '@cloudflare/workerd-linux-arm64@1.20260825.1':
+    resolution: {integrity: sha512-a5E61YsnNCHHQMnmYsbVXInzeYqFqAMwm/wo16dWW4klXDr6T1bm7u1h5G7ZkxVM7+rtc69oe0yVHjDEqzpYVg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260730.1':
-    resolution: {integrity: sha512-27fAN+vUECW1oYVc1KOcHYpkL8COM2Uxtxql7TL595kxbjoqS5yckw7NLz7bTf2pALFCZWjqXDjZGJ/xbG4ZKQ==}
+  '@cloudflare/workerd-windows-64@1.20260825.1':
+    resolution: {integrity: sha512-EokzVY2suzRSzeURi2HpHnySR5mo6aF5V1klFIqFOZp2YJyXXTI8AvQgYzhlmGTZY3LNL41jjkUQunOM2OErgQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -3650,8 +3651,8 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  miniflare@5.20260730.0-alpha:
-    resolution: {integrity: sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q==}
+  miniflare@5.20260825.0-alpha:
+    resolution: {integrity: sha512-ZwlF6LuX43ilx9EwMRDKHenoGXiNdcKSyGx5aPaJhuozujVZasb2lRR7t3ojJZSnVzwDPsBBYCu8lLnc+/KIgQ==}
     engines: {node: '>=22.0.0'}
 
   minimatch@10.2.6:
@@ -3671,8 +3672,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4194,8 +4195,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -4381,17 +4382,17 @@ packages:
     resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
     engines: {node: '>=12.17'}
 
-  workerd@1.20260730.1:
-    resolution: {integrity: sha512-zmfNIjwYSWFY5chGBOjWtH3xAE7p97FTC6vR4Ep98290ho6AeAR/NVcBD274YCLEUYzqm8yxdtZlxMybU8a3jA==}
+  workerd@1.20260825.1:
+    resolution: {integrity: sha512-ccS6TEaaRxgONKawiYGnFYUVGfr2pmN1b7mrNtw0ADVhFaYsEIVoCHnQ4UjhM9EJDzuaNgAWFY82nzVrjWpuOA==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.118.0:
-    resolution: {integrity: sha512-9pkBw/b8zWqGx2S+oLhgHMR1M/4VOE8SynUFABnGWiSFGlcOQ4xiI/B71Xf66RYP2xzngU37IQFPtUruij3lYw==}
+  wrangler@4.126.0:
+    resolution: {integrity: sha512-glDq/nxaeQwue0XMIeupfwlu2jVxnFs+wjDFT71DQuURN5LsVdCwu0Af/1ep10U5xr1rKPGhHDEDkKG9nxE/dg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^5.20260730.1
+      '@cloudflare/workers-types': ^5.20260825.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -4673,25 +4674,25 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260730.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260825.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260730.1
+      workerd: 1.20260825.1
 
-  '@cloudflare/workerd-darwin-64@1.20260730.1':
+  '@cloudflare/workerd-darwin-64@1.20260825.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260730.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260825.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260730.1':
+  '@cloudflare/workerd-linux-64@1.20260825.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260730.1':
+  '@cloudflare/workerd-linux-arm64@1.20260825.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260730.1':
+  '@cloudflare/workerd-windows-64@1.20260825.1':
     optional: true
 
   '@codemirror/autocomplete@6.20.3':
@@ -7917,12 +7918,12 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  miniflare@5.20260730.0-alpha:
+  miniflare@5.20260825.0-alpha:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
-      undici: 7.28.0
-      workerd: 1.20260730.1
+      undici: 7.29.0
+      workerd: 1.20260825.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -7943,7 +7944,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -8083,7 +8084,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -8588,7 +8589,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -8737,24 +8738,24 @@ snapshots:
 
   wordwrapjs@5.1.1: {}
 
-  workerd@1.20260730.1:
+  workerd@1.20260825.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260730.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260730.1
-      '@cloudflare/workerd-linux-64': 1.20260730.1
-      '@cloudflare/workerd-linux-arm64': 1.20260730.1
-      '@cloudflare/workerd-windows-64': 1.20260730.1
+      '@cloudflare/workerd-darwin-64': 1.20260825.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260825.1
+      '@cloudflare/workerd-linux-64': 1.20260825.1
+      '@cloudflare/workerd-linux-arm64': 1.20260825.1
+      '@cloudflare/workerd-windows-64': 1.20260825.1
 
-  wrangler@4.118.0:
+  wrangler@4.126.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260730.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260825.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 5.20260730.0-alpha
+      miniflare: 5.20260825.0-alpha
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260730.1
+      workerd: 1.20260825.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -163,17 +163,17 @@ importers:
         specifier: ^0.184.1
         version: 0.184.1
       '@vitejs/plugin-react':
-        specifier: ^6.0.5
-        version: 6.0.5(babel-plugin-react-compiler@1.0.0)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1))
+        specifier: ^6.1.0
+        version: 6.1.0(oxc-transform-react@0.145.0)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1))
       agentation:
         specifier: ^3.0.2
         version: 3.0.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      babel-plugin-react-compiler:
-        specifier: ^1.0.0
-        version: 1.0.0
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
         version: 7.1.1(eslint@10.4.0(jiti@2.7.0))
+      oxc-transform-react:
+        specifier: ^0.145.0
+        version: 0.145.0
       oxfmt:
         specifier: ^0.54.0
         version: 0.54.0
@@ -189,9 +189,6 @@ importers:
       vite:
         specifier: ^8.2.0
         version: 8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)
-      vite-plugin-babel:
-        specifier: ^1.7.3
-        version: 1.7.3(@babel/core@7.29.7)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1))
       wrangler:
         specifier: ^4.118.0
         version: 4.118.0
@@ -912,6 +909,128 @@ packages:
 
   '@oxc-project/types@0.142.0':
     resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+
+  '@oxc-transform-react/binding-android-arm-eabi@0.145.0':
+    resolution: {integrity: sha512-KuK3zAp10yFyeAxIXlZn2ycsFpaKLxUmj5BVRS1io4XfwnKTozb/goZakgKD5JEiHOVOtEKt1r7pTrmW/pFxxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-transform-react/binding-android-arm64@0.145.0':
+    resolution: {integrity: sha512-eDUKx6MAgRAF67JPScjLF6h8lL2qmlvFrXGSG8mYFIVJb++NMyDygiIo8TAKdWQNguoBElUZw/SK2EPRaKsryQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform-react/binding-darwin-arm64@0.145.0':
+    resolution: {integrity: sha512-msCgwbVLswJ08JaUOjfPddieVJwE4IT1Y23A1DDyKVyzZp2ormo9a4ffDEu9nmmovdEj8VqAyFgggsgzIkBVrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform-react/binding-darwin-x64@0.145.0':
+    resolution: {integrity: sha512-R0PtsoOCsARulmWhLG1fFInT+98TRl/H6w6ifi8XOLvpdsksD1rxsw4Ol84lHbdHCcMNjfJTckZzQIZBMiXkLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform-react/binding-freebsd-x64@0.145.0':
+    resolution: {integrity: sha512-/MJ7+IvxfutSGqn6hIXU92wGNk5FlkqbTHM+kEl7ytLLOSAyivYhF2gxdYMmXTwOG56k2XviMcE0D/TBjdyoRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform-react/binding-linux-arm-gnueabihf@0.145.0':
+    resolution: {integrity: sha512-ssHZ0W2wSjQwaBQdkg8u+A7dTdw2vkGSK0hRfCoDCkRkETu+19Q8Tae7NNxlYHcP1iUQYhEj8Qfgpq+S/MdrYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform-react/binding-linux-arm-musleabihf@0.145.0':
+    resolution: {integrity: sha512-adJy4lQVcoIW6CUzQYbDgbHZMDSLoizwCinG2Dex29jdACKwIgXQQrIAHAgfveaZleKIB/rf3usGoRcOGyfz7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform-react/binding-linux-arm64-gnu@0.145.0':
+    resolution: {integrity: sha512-7KRa0CC1FaSKx5sy+bDtqGvXF+RiVoMmSe8OmTKm9kRZkNVdmsmpnsQhgravehTohlWDveo5aoGMwcFtffGDmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-arm64-musl@0.145.0':
+    resolution: {integrity: sha512-fGhZkDnk2RoMp6THas9HFGorF0A1wwPPA/2Lu9IUO1ip5MJqS/JG7/conmiz0DBG0PWBtnKl2Y8sA/VBiD/oQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-linux-ppc64-gnu@0.145.0':
+    resolution: {integrity: sha512-VBaUTjRZYRypD2tL7cmbM2Fn6fvTnacLQ1GdsU1Y6A3fkqA/z+wc5Vy1QnnuFe9sIwb9xCvSS2tJVlucR39FYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-riscv64-gnu@0.145.0':
+    resolution: {integrity: sha512-s2cimMVAmWe9dtjyWdGsYtevi9C7gJoOXwrCZD0BX7hgyGmuBO3iWQjx4W48hdXlWS176NoxuFIHAN72N86upA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-riscv64-musl@0.145.0':
+    resolution: {integrity: sha512-hFPrsL2nKL4aa8vFmheR53PcrxQgym8bnaSD1pMX9IoyQq+/ksAuw1CDJSV9c5xhxxZdw/KTPVer7M/6OQvfoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-linux-s390x-gnu@0.145.0':
+    resolution: {integrity: sha512-YLKhySqqu0JAtT0z8GuaFF7Hht3IvQLZShTH0DxeV28NwSthva+qJ7GN09ALT1bqRVvMjNGycgPHaGSWBUIt7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-x64-gnu@0.145.0':
+    resolution: {integrity: sha512-WqgJ+0M9mwQ1cRfSgk4vzYudD2imLSBhUZ2QFes06vUjigts5Dw4NajWKc2JibPHYsoiUA9Zj39zWwC5AxXEGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-x64-musl@0.145.0':
+    resolution: {integrity: sha512-eIre/TjGt07IVKoWUrUOkPxN7UKeWxbiGvCywoGLDRe1/2K50MrA2vQahZ8AlW5CLmajOr9ePKrkRzLg1fa0cQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-openharmony-arm64@0.145.0':
+    resolution: {integrity: sha512-zhWiyJ+9XD4cuhSZIT6aozuXDHcZHNdoVe88xVmx2XN00anjZ6VAGj31rhD8ndha/F8NllcQEr8Q61Dr2MHv5Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform-react/binding-win32-arm64-msvc@0.145.0':
+    resolution: {integrity: sha512-Q0oiZfrfYyhmpqH2K0dylDTooIadecGsoiQks7G0AbuszCu2I7zYyJo4ArFc3d5Hj49Jjc5dDAE5WP/Sg2p8hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform-react/binding-win32-ia32-msvc@0.145.0':
+    resolution: {integrity: sha512-ERpriVJY5S8hXd3BJi4UtzsIVsEQnntmpqTgRqh0XCaflLRLTQnPWpkO8rgtI7xye5MRhfhA+qsxKg2olJs4qA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform-react/binding-win32-x64-msvc@0.145.0':
+    resolution: {integrity: sha512-sa781BGPLDw8+7ATrgUpLr0f4t0Q14O+zk3fOuQbUpjW5jERc9a3k1xIYKX1JkTG/sszoFhi8LzyCoMC49tkWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@oxfmt/binding-android-arm-eabi@0.54.0':
     resolution: {integrity: sha512-NAtpl/SiaeU103e7/OmZw0MvUnsUUopW7hEm/ecegJg7YM0skQaA0IXEZoyTV6NUdiNPupdIUreRqUZTShbn/g==}
@@ -2421,17 +2540,20 @@ packages:
     peerDependencies:
       react: '>= 16.8.0'
 
-  '@vitejs/plugin-react@6.0.5':
-    resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
+  '@vitejs/plugin-react@6.1.0':
+    resolution: {integrity: sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
       babel-plugin-react-compiler: ^1.0.0
+      oxc-transform-react: ^0.145.0
       vite: ^8.0.0
     peerDependenciesMeta:
       '@rolldown/plugin-babel':
         optional: true
       babel-plugin-react-compiler:
+        optional: true
+      oxc-transform-react:
         optional: true
 
   acorn-jsx@5.3.2:
@@ -2497,9 +2619,6 @@ packages:
 
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
-
-  babel-plugin-react-compiler@1.0.0:
-    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -3602,6 +3721,10 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  oxc-transform-react@0.145.0:
+    resolution: {integrity: sha512-y8cfjow11WKvDekonySPVvRUvNuIvqNT0LZ0Aey6j5dsNUD6k4hy6Mae/SLmng5egmb1GdJS11GduJ+IoEAXEw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   oxfmt@0.54.0:
     resolution: {integrity: sha512-DjnMwn7smSLF+Mc2+pRItnuPftm/dkUFpY/d4+33y9TfKrsHZo8GLhmUg9BrOIUEy94Rlom1Q11N6vuhE+e0oQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4181,12 +4304,6 @@ packages:
 
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
-
-  vite-plugin-babel@1.7.3:
-    resolution: {integrity: sha512-PsomVbH74/XyqMzXSwBDqb/1o5sAqE68gPlHLfx4FiMGbvKDhaZVQNv/gj/7oRQ5BvuIlyTKBtNEA9MnirGwRA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      vite: ^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   vite@8.2.0:
     resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
@@ -5035,6 +5152,63 @@ snapshots:
   '@oozcitak/util@10.0.0': {}
 
   '@oxc-project/types@0.142.0': {}
+
+  '@oxc-transform-react/binding-android-arm-eabi@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-android-arm64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-darwin-arm64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-darwin-x64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-freebsd-x64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm-gnueabihf@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm-musleabihf@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm64-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm64-musl@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-ppc64-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-riscv64-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-riscv64-musl@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-s390x-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-x64-gnu@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-x64-musl@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-openharmony-arm64@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-arm64-msvc@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-ia32-msvc@0.145.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-x64-msvc@0.145.0':
+    optional: true
 
   '@oxfmt/binding-android-arm-eabi@0.54.0':
     optional: true
@@ -6495,12 +6669,12 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.8
 
-  '@vitejs/plugin-react@6.0.5(babel-plugin-react-compiler@1.0.0)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1))':
+  '@vitejs/plugin-react@6.1.0(oxc-transform-react@0.145.0)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)
     optionalDependencies:
-      babel-plugin-react-compiler: 1.0.0
+      oxc-transform-react: 0.145.0
 
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
@@ -6574,10 +6748,6 @@ snapshots:
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
-
-  babel-plugin-react-compiler@1.0.0:
-    dependencies:
-      '@babel/types': 7.29.8
 
   bail@2.0.2: {}
 
@@ -7806,6 +7976,28 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  oxc-transform-react@0.145.0:
+    optionalDependencies:
+      '@oxc-transform-react/binding-android-arm-eabi': 0.145.0
+      '@oxc-transform-react/binding-android-arm64': 0.145.0
+      '@oxc-transform-react/binding-darwin-arm64': 0.145.0
+      '@oxc-transform-react/binding-darwin-x64': 0.145.0
+      '@oxc-transform-react/binding-freebsd-x64': 0.145.0
+      '@oxc-transform-react/binding-linux-arm-gnueabihf': 0.145.0
+      '@oxc-transform-react/binding-linux-arm-musleabihf': 0.145.0
+      '@oxc-transform-react/binding-linux-arm64-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-arm64-musl': 0.145.0
+      '@oxc-transform-react/binding-linux-ppc64-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-riscv64-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-riscv64-musl': 0.145.0
+      '@oxc-transform-react/binding-linux-s390x-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-x64-gnu': 0.145.0
+      '@oxc-transform-react/binding-linux-x64-musl': 0.145.0
+      '@oxc-transform-react/binding-openharmony-arm64': 0.145.0
+      '@oxc-transform-react/binding-win32-arm64-msvc': 0.145.0
+      '@oxc-transform-react/binding-win32-ia32-msvc': 0.145.0
+      '@oxc-transform-react/binding-win32-x64-msvc': 0.145.0
+
   oxfmt@0.54.0:
     dependencies:
       tinypool: 2.1.0
@@ -8509,11 +8701,6 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
-
-  vite-plugin-babel@1.7.3(@babel/core@7.29.7)(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)):
-    dependencies:
-      '@babel/core': 7.29.7
-      vite: 8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1)
 
   vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.1):
     dependencies:

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,6 +1,5 @@
 overrides:
   typescript: ^6.0.3
-  # postcss accepts any nanoid ^3.3.x, which keeps resolving to 3.3.16 (GHSA-2v37-7h3g-55p8).
   nanoid: ^3.3.18
 
 onlyBuiltDependencies:

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 overrides:
   typescript: ^6.0.3
+  # postcss accepts any nanoid ^3.3.x, which keeps resolving to 3.3.16 (GHSA-2v37-7h3g-55p8).
+  nanoid: ^3.3.18
 
 onlyBuiltDependencies:
   - "@tailwindcss/oxide"

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -5,10 +5,6 @@ import { defineConfig, type Plugin } from "vite";
 
 import { annotateSource } from "./plugins/annotate-source.mjs";
 
-// React Compiler options, forwarded to the Rust port in `oxc-transform-react`.
-// https://react.dev/reference/react-compiler/configuration
-const reactCompilerConfig = {};
-
 const annotation = annotateSource();
 
 // recharts imports es-toolkit's deep `es-toolkit/compat/<name>` modules, whose
@@ -64,16 +60,8 @@ export default defineConfig({
       },
       pages: [{ path: "/" }, { path: "/blog" }, { path: "/sitemap.xml" }, { path: "/sitemap_index.xml" }],
     }),
-    // Runs its own Babel pass, ahead of the React transform below: it has to see
-    // route modules while TanStack's source map is still readable, which is
-    // before any non-`pre` plugin gets them. Set VITE_ANNOTATE=0 to skip the
-    // pass for faster dev HMR.
     annotation.vitePlugin,
-    // React Compiler runs inside the plugin's own oxc pass (`oxc-transform-react`,
-    // the Rust port), alongside the TypeScript and JSX transforms. Unlike the
-    // Babel plugin it replaced, it is cheap enough to keep on in dev, so dev and
-    // production now compile the same way.
-    viteReact({ compiler: reactCompilerConfig }),
+    viteReact({ compiler: true }),
     tailwindcss(),
   ],
 });

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -2,12 +2,12 @@ import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import viteReact from "@vitejs/plugin-react";
 import { defineConfig, type Plugin } from "vite";
-import babel from "vite-plugin-babel";
 
 import { annotateSource } from "./plugins/annotate-source.mjs";
 
-const ReactCompilerConfig = {};
-const isDev = process.env.NODE_ENV !== "production";
+// React Compiler options, forwarded to the Rust port in `oxc-transform-react`.
+// https://react.dev/reference/react-compiler/configuration
+const reactCompilerConfig = {};
 
 const annotation = annotateSource();
 
@@ -64,26 +64,16 @@ export default defineConfig({
       },
       pages: [{ path: "/" }, { path: "/blog" }, { path: "/sitemap.xml" }, { path: "/sitemap_index.xml" }],
     }),
-    // Runs its own Babel pass rather than sharing the React Compiler one below:
-    // it has to see route modules while TanStack's source map is still readable,
-    // which is before any non-`pre` plugin gets them. Set VITE_ANNOTATE=0 to
-    // skip the pass for faster dev HMR.
+    // Runs its own Babel pass, ahead of the React transform below: it has to see
+    // route modules while TanStack's source map is still readable, which is
+    // before any non-`pre` plugin gets them. Set VITE_ANNOTATE=0 to skip the
+    // pass for faster dev HMR.
     annotation.vitePlugin,
-    viteReact(),
-    // React Compiler via Babel — only run for production builds (slow in dev)
-    ...(!isDev
-      ? [
-          babel({
-            include: ["./src/**/*"],
-            filter: /\.[jt]sx?$/,
-            babelConfig: {
-              presets: ["@babel/preset-typescript"],
-              plugins: [["babel-plugin-react-compiler", ReactCompilerConfig]],
-              sourceMaps: true,
-            },
-          }),
-        ]
-      : []),
+    // React Compiler runs inside the plugin's own oxc pass (`oxc-transform-react`,
+    // the Rust port), alongside the TypeScript and JSX transforms. Unlike the
+    // Babel plugin it replaced, it is cheap enough to keep on in dev, so dev and
+    // production now compile the same way.
+    viteReact({ compiler: reactCompilerConfig }),
     tailwindcss(),
   ],
 });


### PR DESCRIPTION
## Description

Two things, in three commits.

**1. React Compiler: Babel → the Rust (oxc) port.** `@vitejs/plugin-react` 6.1 added a `compiler` option backed by [`oxc-transform-react`](https://www.npmjs.com/package/oxc-transform-react) — the Rust port of React Compiler. It runs inside the plugin's existing oxc pass, alongside the TypeScript and JSX transforms, so the separate `vite-plugin-babel` pass and its `babel-plugin-react-compiler` dependency are no longer needed.

```diff
-    viteReact(),
-    // React Compiler via Babel — only run for production builds (slow in dev)
-    ...(!isDev ? [babel({ /* babel-plugin-react-compiler */ })] : []),
+    viteReact({ compiler: true }),
```

The Babel pass was gated to production builds because it was too slow for dev HMR. The oxc one is not, so **the gate is gone and dev now compiles the same way production does** — memo caches (`_c(n)`) show up in dev-transformed modules instead of only in the production bundle.

| | |
|---|---|
| bumped | `@vitejs/plugin-react` `^6.0.5` → `^6.1.0` |
| added | `oxc-transform-react` `^0.145.0` (optional peer of the above; pinned to the range 6.1.0 declares) |
| removed | `vite-plugin-babel`, `babel-plugin-react-compiler` |
| kept | `@babel/core`, `@babel/preset-typescript` — `plugins/annotate-source.mjs` still runs its own Babel pass |

**2. Clearing the `pnpm audit` highs.** The audit workflow triggers on `website/package.json` and `website/pnpm-lock.yaml`, so this PR surfaced a failure that has been red on `master` on every scheduled run since 2026-08-04 (last green: run #421, 08-03), [including this morning's run](https://github.com/deadlock-api/deadlock-api/actions/runs/33056021567) on the base commit `e2e79bc`. Not this PR's doing, but the fix is two lines, so it rides along in its own commit:

| Advisory | Package | Path | Fix |
|---|---|---|---|
| [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) | `undici` 7.28.0 → 7.29.0 | `. > wrangler > miniflare > undici` | `wrangler` `^4.118.0` → `^4.126.0`, which pulls `miniflare@5.20260825.0-alpha` and its patched `undici` |
| [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) | `nanoid` 3.3.16 → 3.3.18 | `. > vite > postcss > nanoid` | `nanoid: ^3.3.18` override — `postcss` asks for `^3.3.x` and nothing forces resolution past the pinned 3.3.16 |

`pnpm audit --audit-level high` now exits 0 with "No known vulnerabilities found", clearing all six findings rather than only the two highs.

The third commit is cleanup: `compiler: true` instead of an empty options object behind a `reactCompilerConfig` const, and no added comments — the compiler's behaviour is documented in `website/CLAUDE.md` instead. Net effect on `vite.config.ts` is 24 lines changed, almost all deletions.

## Related Issue

n/a

## Type of Change

- [x] Performance improvement
- [x] Code refactoring (no functional changes)
- [x] Documentation update
- [x] Other: dependency security bumps

## How Has This Been Tested?

- [x] Manual testing

- `pnpm audit --audit-level high` — exit 0, no known vulnerabilities (was 6 findings / 2 high).
- `pnpm typecheck` — clean.
- `pnpm lint` — clean (same pre-existing `jsx-a11y` / `no-map-spread` warnings as before).
- `pnpm fmt --check` — clean across 376 files.
- `pnpm build` — client and server bundles compile: 177 client chunks, 141 `compiler-runtime` imports, 16 compiler bail-outs — identical across all three commits, so neither the audit bump nor `compiler: true` changes the output. The build then fails in the **prerender** step, but only because this sandbox cannot reach `api.deadlock-api.com` (`AxiosError: 403` → `Failed to fetch /: Internal Server Error`); a control build of `master`'s config fails identically. CI has network and got through it on the first commit — the prerender crawled every hero page and `preserve-old-assets` backfilled 112 chunks.
- `pnpm dev` — server boots, and `curl`ing a source module back through Vite shows `_c(n)` memo caches, confirming the compiler now runs in dev. The same request against `master`'s config returns zero, as expected from the old production-only gate.
- Compiler coverage — `compiler-runtime` imports in `dist/client`: 85 with Babel, 141 with oxc, so nothing lost. Raw client assets grow ~60 KB (4.76 MB → 4.83 MB, +1.3%) from the extra memo caches.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings — see the note below on `react-compiler(Todo)`

## Additional Notes

**About the new build warnings.** The oxc pass prints 16 `react-compiler(Todo)` diagnostics across 12 files, for constructs the compiler cannot lower: `try`/`finally`, `throw` inside `try`, and `++`/`--` on a variable captured by a lambda. These are not new bail-outs — they are the same ones `babel-plugin-react-compiler` already hit on the same files and skipped silently. I verified this by running the Babel plugin over each of those files with a `logger` attached; it reports the identical reason for every one. So the affected components were already unoptimized; the warnings are new, the behaviour is not.

`plugins/annotate-source.mjs` itself is untouched — only the comment above its entry in the plugin list, which named the Babel React Compiler pass that no longer exists, and which the third commit drops. Its pass still runs `pre` for the source-map reason that comment described.

`wrangler@4.127.0` would also clear the audit, but it was published today and the repo's `minimum-release-age=1440` rejects it until tomorrow; `4.126.0` (published 08-25) is the newest that installs cleanly.

The Rust port is upstream-flagged as experimental. Rolling back is a one-line change to `vite.config.ts` plus restoring the two dev dependencies; the audit commit is independent and can be dropped on its own.