### PR TITLE
Restore chart animations and skip unchanged sibling renders

### DIFF
--- a/tools/frontend-perf/README.md
+++ b/tools/frontend-perf/README.md
@@ -26,22 +26,23 @@ Each run records eight alternating interactions, component renders/changed props
 API requests, table text, chart paths/legend state, and heatmap draw counts/pixel hashes.
 Report the median of the final seven samples, discarding the first as warmup.
 Times include instrumentation overhead and are local comparisons, not user latency or field Web Vitals.
-Games and duration charts wait 1.8 seconds per interaction to include the baseline animation's entire cost.
+Animated charts wait 1.8 seconds per interaction to include the full animation. Preserve animation behavior in comparisons.
 
 ## Findings
 
 Production builds, Chrome 150 on Linux, 1280×577 at DPR 1, September 5, 2026:
 
+Correction: the earlier games, duration, and purchase-chart figures counted disabling animations as an optimization.
+Those figures are withdrawn. Their original animations are restored; the calculation and rerender fixes remain.
+
 | Interaction | Component renders before → after | Median script ms before → after |
 | --- | ---: | ---: |
 | Hero table: sort win rate | 2,316 → 171 | 19.54 → 7.94 |
 | Experience table: sort trend | 6,463 → 136 | 31.09 → 5.94 |
-| Duration chart: toggle hero | 2,869 → 658 | 75.28 → 17.47 |
-| Games chart: switch kills/deaths | 8,297 → 448 | 93.25 → 12.32 |
 | Heatmap: adjust sensitivity | 49 → 32 | 20.54 → 11.32 |
 | Over-time chart: toggle hero | 1,176 → 815 | 31.07 → 21.95 |
 
-All eight before/after samples have identical table text, final chart paths/legend state, and heatmap pixel hashes
+The retained comparisons have identical table text, final chart paths/legend state, and heatmap pixel hashes
 where applicable. None of these sampled interactions issued API requests. Raw recordings are in ignored `results/`.
 Initial development profiling also covered item sorting, leaderboard search, and the team-builder hero picker.
 
@@ -49,7 +50,6 @@ Hero table cells now remain reusable when row order changes, using the existing 
 Combined query results keep experience and duration data stable across unrelated renders.
 Sidebar links subscribe only to whether their route is active, avoiding 17 renders on query-string changes.
 Unused bump-chart machinery was still measuring SVG paths and scheduling another over-time chart render; it is removed.
-Games and duration charts now update immediately instead of animating all dots when their values or axes change.
 Heatmap normalization uses native typed-array sorting, and its resize observer handles the initial draw without a duplicate.
 
 The grid comparison checks 336 combinations against the baseline, including empty data, all three modes,
@@ -65,12 +65,15 @@ Run `itemTiming`, `itemFlow`, `itemCombos`, or `itemPicker` with `profile.mjs`; 
 
 | Interaction | Component renders before → after | Median script ms before → after |
 | --- | ---: | ---: |
-| Purchase chart: toggle conservative estimate | 13,924 → 526 | 122.36 → 11.46 |
 | Build flow: hover/leave first item | 466 → 245 | 8.18 → 5.03 |
 | Combo table: alternate 100/200 rows | 4,457 → 4,257 | 48.75 → 41.90 |
 
-Purchase charts update immediately; unused moving averages and debug logging are removed. Flow cards reuse their
+Unused moving averages and debug logging are removed. Flow cards reuse their
 contents, and lock pickers retain their callbacks. Combo item cells stay cached and previous-period counts are normalized
 only for displayed rows. Main-table sorting and quick-select toggles were already reusing their rows/cards.
 All eight paired samples match on table text, chart paths, node positions, and hover opacity where applicable, with no API
 requests during sampling. Another 288 chart-data comparisons preserve visible values across bucket types and estimate settings.
+
+Isolation follow-up (eight development samples): flow hover rerenders 0 closed lock pickers instead of 4, and only the
+17 cards whose opacity changes instead of all 24. Combo-limit changes rerender 0 existing item cells instead of 100.
+Targeted `memo` boundaries skip those unchanged siblings. Page/sidebar components stay idle; all captured output matches.

--- a/website/src/components/games-page/GamesOverTimeChart.tsx
+++ b/website/src/components/games-page/GamesOverTimeChart.tsx
@@ -113,7 +113,6 @@ export default function GamesOverTimeChart({
                 />
                 <Line
                   type="monotone"
-                  isAnimationActive={false}
                   dataKey="value"
                   stroke="var(--color-primary)"
                   dot={{ r: 3 }}

--- a/website/src/components/heroes-page/HeroStatsByDurationChart.tsx
+++ b/website/src/components/heroes-page/HeroStatsByDurationChart.tsx
@@ -165,7 +165,6 @@ export function HeroStatsByDurationChart({
                   strokeWidth={2}
                   name={heroIdMap[heroId]?.name}
                   hide={!effectiveVisibleSet.has(heroId)}
-                  isAnimationActive={false}
                   connectNulls
                 />
               ))}

--- a/website/src/components/items-page/ItemBuyTimingChart.tsx
+++ b/website/src/components/items-page/ItemBuyTimingChart.tsx
@@ -377,7 +377,6 @@ export function ItemBuyTimingChart({ itemIds, baseQueryOptions, rowTotalMatches 
                         activeDot={{ r: 6 }}
                         strokeWidth={2}
                         name={itemNameMap?.[itemId]}
-                        isAnimationActive={false}
                       />
                     ))}
                   </LineChart>

--- a/website/src/components/items-page/ItemCombStatsTable.tsx
+++ b/website/src/components/items-page/ItemCombStatsTable.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { parseAsInteger, useQueryState } from "nuqs";
-import { Fragment, useId, useMemo } from "react";
+import { Fragment, memo, useId, useMemo } from "react";
 
 import { ItemImage } from "~/components/ItemImage";
 import { ItemName } from "~/components/ItemName";
@@ -18,7 +18,7 @@ import { api } from "~/lib/api";
 import { itemUpgradesQueryOptions } from "~/queries/asset-queries";
 import { queryKeys } from "~/queries/query-keys";
 
-function ComboItems({ itemIds }: { itemIds: number[] }) {
+const ComboItems = memo(function ComboItems({ itemIds }: { itemIds: number[] }) {
   return (
     <TableCell>
       <div className="flex items-center gap-2">
@@ -34,7 +34,7 @@ function ComboItems({ itemIds }: { itemIds: number[] }) {
       </div>
     </TableCell>
   );
-}
+});
 
 export function ItemCombStatsTable({
   columns,

--- a/website/src/components/items-page/ItemFlowGraph.tsx
+++ b/website/src/components/items-page/ItemFlowGraph.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Lock, Plus } from "lucide-react";
 import { parseAsArrayOf, parseAsInteger, parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ItemImage } from "~/components/ItemImage";
 import { ItemName } from "~/components/ItemName";
@@ -183,7 +183,7 @@ function useContainerWidth() {
   return [ref, width] as const;
 }
 
-function StageLockPicker({
+const StageLockPicker = memo(function StageLockPicker({
   candidates,
   column,
   onLock,
@@ -234,9 +234,9 @@ function StageLockPicker({
       </PopoverContent>
     </Popover>
   );
-}
+});
 
-function ItemFlowCard({
+const ItemFlowCard = memo(function ItemFlowCard({
   node,
   meta,
   dimmed,
@@ -407,7 +407,7 @@ function ItemFlowCard({
       </TooltipContent>
     </Tooltip>
   );
-}
+});
 
 export function ItemFlowGraph({
   heroId,

--- a/website/src/components/items-page/ItemTabsEdgePrototype.tsx
+++ b/website/src/components/items-page/ItemTabsEdgePrototype.tsx
@@ -11,15 +11,12 @@ const tabs = [
 export function ItemTabsEdgePrototype() {
   return (
     <div className="-mx-4 -mb-2 sm:-mx-6">
-      <Tabs.List
-        aria-label="Item analytics"
-        className="flex overflow-x-auto border-b border-white/10 pt-1"
-      >
+      <Tabs.List aria-label="Item analytics" className="flex overflow-x-auto border-b border-white/10 pt-1">
         {tabs.map(([value, label]) => (
           <Tabs.Trigger
             key={value}
             value={value}
-            className="group relative shrink-0 border-t-2 border-transparent px-4 py-3 text-sm font-medium whitespace-nowrap text-muted-foreground transition-colors duration-150 hover:bg-white/[0.025] hover:text-foreground focus-visible:z-10 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary data-[state=active]:border-primary data-[state=active]:bg-white/[0.035] data-[state=active]:text-foreground sm:px-6 motion-reduce:transition-none"
+            className="group relative shrink-0 border-t-2 border-transparent px-4 py-3 text-sm font-medium whitespace-nowrap text-muted-foreground transition-colors duration-150 hover:bg-white/[0.025] hover:text-foreground focus-visible:z-10 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary data-[state=active]:border-primary data-[state=active]:bg-white/[0.035] data-[state=active]:text-foreground motion-reduce:transition-none sm:px-6"
           >
             <span
               aria-hidden="true"

--- a/website/src/components/items-page/ItemTabsJoinedPrototype.tsx
+++ b/website/src/components/items-page/ItemTabsJoinedPrototype.tsx
@@ -16,7 +16,7 @@ export function ItemTabsJoinedPrototype() {
           <Tabs.Trigger
             key={value}
             value={value}
-            className="relative shrink-0 rounded-t-md border border-transparent border-b-white/10 px-4 py-2.5 text-[13px] font-medium whitespace-nowrap text-muted-foreground transition-colors duration-150 hover:bg-white/[0.025] hover:text-foreground focus-visible:z-10 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary data-[state=active]:border-white/10 data-[state=active]:border-b-transparent data-[state=active]:bg-white/[0.025] data-[state=active]:text-foreground sm:px-5 motion-reduce:transition-none"
+            className="relative shrink-0 rounded-t-md border border-transparent border-b-white/10 px-4 py-2.5 text-[13px] font-medium whitespace-nowrap text-muted-foreground transition-colors duration-150 hover:bg-white/[0.025] hover:text-foreground focus-visible:z-10 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-primary data-[state=active]:border-white/10 data-[state=active]:border-b-transparent data-[state=active]:bg-white/[0.025] data-[state=active]:text-foreground motion-reduce:transition-none sm:px-5"
           >
             {label}
           </Tabs.Trigger>

--- a/website/src/components/items-page/ItemTabsTextPrototype.tsx
+++ b/website/src/components/items-page/ItemTabsTextPrototype.tsx
@@ -11,10 +11,7 @@ const options = [
 export function ItemTabsTextPrototype() {
   return (
     <div className="-mx-4 -mb-2 border-t border-white/[0.06] bg-white/[0.015] sm:-mx-6">
-      <Tabs.List
-        aria-label="Item analytics"
-        className="flex min-w-0 gap-1 overflow-x-auto px-2 sm:gap-3 sm:px-4"
-      >
+      <Tabs.List aria-label="Item analytics" className="flex min-w-0 gap-1 overflow-x-auto px-2 sm:gap-3 sm:px-4">
         {options.map(({ value, label }) => (
           <Tabs.Trigger
             key={value}

--- a/website/src/routes/__root.tsx
+++ b/website/src/routes/__root.tsx
@@ -147,7 +147,7 @@ function RootComponent() {
                         WebkitMaskImage: "linear-gradient(to top left, rgba(0,0,0,1) 10%, rgba(0,0,0,0.15) 80%)",
                       }}
                     />
-                    <div className="relative m-2 min-h-[calc(100dvh-1rem)] min-w-0 w-full rounded-xl border border-white/10 bg-background/60 p-4 shadow-xl backdrop-blur-md sm:p-6 xl:w-[92%]">
+                    <div className="relative m-2 min-h-[calc(100dvh-1rem)] w-full min-w-0 rounded-xl border border-white/10 bg-background/60 p-4 shadow-xl backdrop-blur-md sm:p-6 xl:w-[92%]">
                       <Breadcrumbs />
                       <QueryErrorResetBoundary>
                         {({ reset }) => (


### PR DESCRIPTION
## Description
Restore the original animations in games, hero-duration, and item-purchase charts. Stat changes and legend clicks animate again, and the performance report withdraws figures that counted disabling animations as an optimization.

Add targeted memo boundaries so hovering a flow card leaves closed lock pickers and unchanged cards idle, and changing the combo limit preserves existing item cells. Keep the calculation and rendering improvements from the previous passes. Also format four existing layout files required by Website CI.

## Type of Change
- [x] Bug fix
- [x] Performance improvement
- [x] Documentation update

## How Has This Been Tested?
- Full-website formatting, TypeScript, lint, and the production build pass; six pre-existing lint warnings remain.
- Browser frame sampling confirms all three charts animate and settle.
- Eight paired interaction samples preserve table text, chart paths, node positions, and hover opacity.
- Flow hover: closed picker renders 4 → 0; card renders 24 → 17, with only `dimmed` changing on those 17 cards.
- Combo-limit changes: existing item-cell renders 100 → 0; newly displayed cells still mount.
- Surrounding page/sidebar components stay idle; lock pickers still open normally.

## Checklist
- [x] Code follows the project style and has been reviewed.
- [x] Documentation is updated.
- [x] No new warnings.
